### PR TITLE
Add __repr__ for QueryFilter

### DIFF
--- a/labkey/query.py
+++ b/labkey/query.py
@@ -364,3 +364,6 @@ class QueryFilter:
     def get_column_name(self):
         return self.column_name
 
+    def __repr__(self):
+        return '<QueryFilter [{} {} {}]>'.format(self.column_name, self.filter_type, self.value)
+


### PR DESCRIPTION
This PR adds a `__repr__` function for the `QueryFilter` class. It can often be helpful to see what a query filter is while debugging, in an interactive session, etc. 

Currently, such interactive output looks like this:
```
In [43]: fa
Out[43]: 
[<labkey.query.QueryFilter at 0x7f899bace390>,
 <labkey.query.QueryFilter at 0x7f899bace7f0>,
 <labkey.query.QueryFilter at 0x7f899bacec18>,
 <labkey.query.QueryFilter at 0x7f899bace828>,
 <labkey.query.QueryFilter at 0x7f899bace4a8>,
 <labkey.query.QueryFilter at 0x7f899bacee80>,
 <labkey.query.QueryFilter at 0x7f899bace780>,
 <labkey.query.QueryFilter at 0x7f899baced68>,
 <labkey.query.QueryFilter at 0x7f899bace8d0>,
 <labkey.query.QueryFilter at 0x7f899bace588>,
 <labkey.query.QueryFilter at 0x7f899bae0080>,
 <labkey.query.QueryFilter at 0x7f899bae00f0>,
 <labkey.query.QueryFilter at 0x7f899bae0160>,
 <labkey.query.QueryFilter at 0x7f899bae01d0>,
 <labkey.query.QueryFilter at 0x7f899bae0240>,
 <labkey.query.QueryFilter at 0x7f899bae0278>,
 <labkey.query.QueryFilter at 0x7f899bae02b0>,
 <labkey.query.QueryFilter at 0x7f899bae0320>,
 <labkey.query.QueryFilter at 0x7f899bae0390>,
 <labkey.query.QueryFilter at 0x7f899bae03c8>,
 <labkey.query.QueryFilter at 0x7f899bae0438>]
```

This PR changes the above to now look something like this:
```
In [4]: fa
Out[4]: 
[<QueryFilter [FOVId eq 1]>,
 <QueryFilter [WellId eq 24822]>,
 <QueryFilter [InstrumentId eq 5]>,
 <QueryFilter [SourceImageFileId startswith 099d3347dc5148a881d86d2f0a7dedf4]>,
 <QueryFilter [Objective eq 100.0]>,
 <QueryFilter [CenterX eq 54006.85]>,
 <QueryFilter [CenterY eq 42264.327]>,
 <QueryFilter [CenterZ eq 11207.051]>,
 <QueryFilter [CenterUnits eq 3]>,
 <QueryFilter [OriginXY eq 1]>,
 <QueryFilter [OriginZ eq 1]>,
 <QueryFilter [DimensionX eq 924.0]>,
 <QueryFilter [DimensionY eq 624.0]>,
 <QueryFilter [DimensionZ eq 65.0]>,
 <QueryFilter [DimensionUnits eq 8]>,
 <QueryFilter [PixelScaleX eq 0.10833333333333332]>,
 <QueryFilter [PixelScaleY eq 0.10833333333333332]>,
 <QueryFilter [PixelScaleZ eq 0.29]>,
 <QueryFilter [PixelScaleUnits eq 3]>,
 <QueryFilter [FOVImageDate eq 2017/06/23 17:50:55]>,
 <QueryFilter [QCStatusId contains 1]>]
```