### PR TITLE
Add __repr__ for ServerContext

### DIFF
--- a/labkey/utils.py
+++ b/labkey/utils.py
@@ -49,6 +49,11 @@ class ServerContext(object):
         else:
             self._scheme = 'http://'
 
+    def __repr__(self):
+        return '<ServerContext [ {} | {} | {} ]>'.format(self._domain,
+                                                         self._context_path,
+                                                         self._container_path)
+
     def build_url(self, controller, action, container_path=None):
         # type: (self, str, str, str) -> str
         sep = '/'


### PR DESCRIPTION
Follow up to #16, this adds a `__repr__` to the `ServerContext` class to show some of the key identifiers of the class. Previously, this would look like:
```
In [1]: import labkey                                                                                                                                                                                                                         

In [2]: labkey.utils.create_server_context('foo', 'bar', 'labkey', use_ssl=False)                                                                                                                                                             
Out[2]: <labkey.utils.ServerContext at 0x7f07c56fd5f8>

In [3]: labkey.utils.create_server_context('foolocal:8080', 'bar', 'labkey', use_ssl=False)                                                                                                                                                   
Out[3]: <labkey.utils.ServerContext at 0x7f07c77456a0>
```

Now this looks like:
```
n [1]: import labkey                                                                                                                                                                                                                         

In [2]: labkey.utils.create_server_context('foo', 'bar', 'labkey', use_ssl=False)                                                                                                                                                             
Out[2]: <ServerContext [ foo | bar | labkey ]>

In [3]: labkey.utils.create_server_context('foolocal:8080', 'bar', 'labkey', use_ssl=False)                                                                                                                                                   
Out[3]: <ServerContext [ foolocal:8080 | bar | labkey ]>
```