### PR TITLE
Make tests python 2 and 3 compatible

### DIFF
--- a/test/test_query_api.py
+++ b/test/test_query_api.py
@@ -247,18 +247,13 @@ class TestSelectRows(unittest.TestCase):
 
     def test_query_filter(self):
         test = self
-        # Construct a set of arguments that
-        args = [
-            *self.args,
-            # view_name
-            None,
-            # filter_array
-            [
-                QueryFilter('Field1', 'value', 'eq'),
-                QueryFilter('Field2', 'value1', 'contains'),
-                QueryFilter('Field2', 'value2', 'contains'),
-            ]
+        view_name = None
+        filter_array = [
+            QueryFilter('Field1', 'value', 'eq'),
+            QueryFilter('Field2', 'value1', 'contains'),
+            QueryFilter('Field2', 'value2', 'contains'),
         ]
+        args = list(self.args) + [view_name, filter_array]
         # Expected query field values in post request body
         query_field = {
             'query.Field1~eq': ['value'],


### PR DESCRIPTION
Apparently the pattern of `[*some_list_or_tuple, other, args]` is not Python 2 compatible. With this PR all of the tests pass in Python 2 or 3 when you run `python setup.py test`.