### PR TITLE
Update changelog. Make bdist_wheel default to universal.

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,15 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 1.1.0 package
+==============================
+
+*Release date: 05/07/2019*
+
+- Add isblank and isnonblank filter types (#23)
+- Fix issue with Query API overwriting query filters with the same field/comparison (#20)
+- Use pytest as the default test runner (#24)
+
 What's New in the LabKey 1.0.1 package
 ==============================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ addopts = -v --cov=labkey --cov-config=setup.cfg --cov-report=html --cov-report=
 [coverage:html]
 directory = build/coverage_html
 title = Test coverage report for labkey
+
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
Forgot to update the changelog for the release. I also added a config option to our setup.cfg that makes bdist_wheel default to universal mode so we don't have to use `python setup.py bdist_wheel --universal`. Now you just use `python setup.py bdist_wheel`