### PR TITLE
7112: Conditional Formats of Fields

### DIFF
--- a/labkey/domain.py
+++ b/labkey/domain.py
@@ -309,45 +309,60 @@ class PropertyValidator(object):
         return strip_none_values(data, strip_none)
 
 
-def get_filter_format(filter):
-    return 'format.column~{}={}'.format(filter.filter_type, filter.value)
+def conditional_format(query_filter, bold=False, italic=False, strike_through=False, text_color="",
+                       background_color=""):
+    # type: (any, bool, bool, bool, str, str) -> ConditionalFormat
+    """
+    Creates a conditional format for use with an existing domain.
+    Supports filter URL format as well as QueryFilter filter parameters.
+    """
+    filter_str = ''
+    if isinstance(query_filter, QueryFilter):
+        filter_str = encode_conditional_format_filter(query_filter)
+    elif isinstance(query_filter, list):
+        if len(query_filter) > 2:
+            raise Exception('Too many QueryFilters given for one conditional format.')
+        if (not isinstance(query_filter[0], QueryFilter)) or \
+           (len(query_filter) > 1 and not isinstance(query_filter[1], QueryFilter)):
+            raise Exception('Please pass QueryFilter objects when updating a conditional format using a list filter.')
 
-
-# Used in updating conditional formats for existing domains. Supports filter URL format as well as QueryFilter
-# filter parameters
-def conditional_format(filter=QueryFilter.Types.HAS_ANY_VALUE, bold=False, italic=False, strikethrough=False,
-                       text_color="", background_color=""):
-    if isinstance(filter, QueryFilter):
-        filter = get_filter_format(filter)  # Replaces QueryFilter obj with string form
-    if isinstance(filter, list):
-        if len(filter) > 2:
-            raise Exception("Too many QueryFilters given for one conditional format.")
-        if (not isinstance(filter[0], QueryFilter)) or (len(filter) > 1 and not isinstance(filter[1], QueryFilter)):
-            raise Exception("Please pass QueryFilter objects when updating a conditional format using a list filter.")
-
-        stringFilters = list(map(lambda filter: get_filter_format(filter), filter))
-        filter = stringFilters[0] + '&' + stringFilters[1] if len(filter) == 2 else stringFilters[0]
+        string_filters = list(map(lambda f: encode_conditional_format_filter(f), query_filter))
+        filter_str = string_filters[0] + '&' + string_filters[1] if len(query_filter) == 2 else string_filters[0]
+    else:
+        filter_str = query_filter
 
     cf = ConditionalFormat.from_data({
-        'filter': filter, 'bold': bold, 'italic': italic, 'strikethrough': strikethrough,
-        'textColor': text_color, 'backgroundColor': background_color
+        'background_color': background_color,
+        'bold': bold,
+        'filter': filter_str,
+        'italic': italic,
+        'strike_through': strike_through,
+        'text_color': text_color,
     })
 
     return cf
 
 
-# For every conditional format filter that is set as a QueryFilter, translates the given filter into LabKey
-# filter URL format
-def format_conditional_filters(field):
+def encode_conditional_format_filter(query_filter):
+    # type: (QueryFilter) -> str
+    return 'format.column~{}={}'.format(query_filter.filter_type, query_filter.value)
+
+
+def __format_conditional_filters(field):
+    # type: (dict) -> dict
+    """
+    For every conditional format filter that is set as a QueryFilter, translates the given filter into LabKey
+    filter URL format.
+    """
     if 'conditionalFormats' in field:
         for cf in field['conditionalFormats']:
             if 'filter' in cf and isinstance(cf['filter'], QueryFilter):  # Supports one QueryFilter without list form
-                cf['filter'] = get_filter_format(cf['filter'])
+                cf['filter'] = encode_conditional_format_filter(cf['filter'])
 
             elif 'filter' in cf and isinstance(cf['filter'], list):  # Supports list of QueryFilters
                 filters = []
                 for query_filter in cf['filter']:
-                    filters.append(get_filter_format(query_filter))
+                    filters.append(encode_conditional_format_filter(query_filter))
                 if len(filters) > 2:
                     raise Exception("Too many QueryFilters given for one conditional format.")
                 cf['filter'] = filters[0] + '&' + filters[1] if len(filters) == 2 else filters[0]
@@ -373,7 +388,7 @@ def create(server_context, domain_definition, container_path=None):
     domain = None
 
     domain_fields = domain_definition['domainDesign']['fields']
-    domain_definition['domainDesign']['fields'] = list(map(format_conditional_filters, domain_fields))
+    domain_definition['domainDesign']['fields'] = list(map(__format_conditional_filters, domain_fields))
     raw_domain = server_context.make_request(url, json_dumps(domain_definition), headers=headers)
 
     if raw_domain is not None:

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -377,10 +377,12 @@ class QueryFilter:
 
         MEMBER_OF = 'memberof'
 
-    def __init__(self, column, value, filter_type=Types.EQUAL):
+    def __init__(self, column, value, filter_type=Types.EQUAL, second_value=None, second_filter_type=Types.EQUAL):
         self.column_name = column
         self.value = value
         self.filter_type = filter_type
+        self.second_value = second_value
+        self.second_filter_type = second_filter_type
 
     def get_url_parameter_name(self):
         return 'query.' + self.column_name + '~' + self.filter_type
@@ -390,6 +392,14 @@ class QueryFilter:
 
     def get_column_name(self):
         return self.column_name
+
+    def get_filter_format(self):
+        second_condition = None
+        if self.second_value or self.second_filter_type:
+            second_condition = '&format.column~{}={}'.format(self.second_filter_type, self.second_value)
+
+        return 'format.column~{}={}{}'.format(self.filter_type, self.value,
+                                               second_condition if second_condition else '')
 
     def __repr__(self):
         return '<QueryFilter [{} {} {}]>'.format(self.column_name, self.filter_type, self.value)

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -377,12 +377,10 @@ class QueryFilter:
 
         MEMBER_OF = 'memberof'
 
-    def __init__(self, column, value, filter_type=Types.EQUAL, second_value=None, second_filter_type=Types.EQUAL):
+    def __init__(self, column, value, filter_type=Types.EQUAL):
         self.column_name = column
         self.value = value
         self.filter_type = filter_type
-        self.second_value = second_value
-        self.second_filter_type = second_filter_type
 
     def get_url_parameter_name(self):
         return 'query.' + self.column_name + '~' + self.filter_type
@@ -392,14 +390,6 @@ class QueryFilter:
 
     def get_column_name(self):
         return self.column_name
-
-    def get_filter_format(self):
-        second_condition = None
-        if self.second_value or self.second_filter_type:
-            second_condition = '&format.column~{}={}'.format(self.second_filter_type, self.second_value)
-
-        return 'format.column~{}={}{}'.format(self.filter_type, self.value,
-                                               second_condition if second_condition else '')
 
     def __repr__(self):
         return '<QueryFilter [{} {} {}]>'.format(self.column_name, self.filter_type, self.value)

--- a/samples/domain_example.py
+++ b/samples/domain_example.py
@@ -125,8 +125,8 @@ list_with_cf = {
             'name': 'date',
             'rangeURI': 'date',
             'conditionalFormats': [{
-                'filter': QueryFilter('date', '10/29/1995', QueryFilter.Types.DATE_GREATER_THAN,
-                                      '10/31/1995', QueryFilter.Types.DATE_LESS_THAN),
+                'filter': [QueryFilter('date', '10/29/1995', QueryFilter.Types.DATE_GREATER_THAN),
+                           QueryFilter('date', '10/31/1995', QueryFilter.Types.DATE_LESS_THAN)],
                 'textcolor': 'f44e3b',
                 'backgroundcolor': 'fcba03',
                 'bold': True,

--- a/samples/domain_example.py
+++ b/samples/domain_example.py
@@ -125,8 +125,10 @@ list_with_cf = {
             'name': 'date',
             'rangeURI': 'date',
             'conditionalFormats': [{
-                'filter': [QueryFilter('date', '10/29/1995', QueryFilter.Types.DATE_GREATER_THAN),
-                           QueryFilter('date', '10/31/1995', QueryFilter.Types.DATE_LESS_THAN)],
+                'filter': [
+                    QueryFilter('date', '10/29/1995', QueryFilter.Types.DATE_GREATER_THAN),
+                    QueryFilter('date', '10/31/1995', QueryFilter.Types.DATE_LESS_THAN)
+                ],
                 'textcolor': 'f44e3b',
                 'backgroundcolor': 'fcba03',
                 'bold': True,
@@ -162,10 +164,10 @@ print('The filter on field "' + age_field.name + '" was: ' + age_field.condition
 
 for field in domain_cf.fields:
     if field.name == 'age':
-        cf = domain.conditional_format(filter='format.column~eq=30', text_color='ff0000')
+        cf = domain.conditional_format(query_filter='format.column~eq=30', text_color='ff0000')
         field.conditional_formats = [cf]
     if field.name == 'date':
-        cf = domain.conditional_format(filter=QueryFilter('date', "10/30/1995", QueryFilter.Types.DATE_LESS_THAN),
+        cf = domain.conditional_format(query_filter=QueryFilter('date', '10/30/1995', QueryFilter.Types.DATE_LESS_THAN),
                                        text_color='f44e3b')
         field.conditional_formats = [cf]
 
@@ -179,5 +181,5 @@ for field in domain_cf.fields:
     if field.name == 'age':
         field.conditional_formats = []
 
-# CLeanup
+# Cleanup
 domain.drop(server_context, 'lists', 'ListWithConditionalFormats')

--- a/samples/domain_example.py
+++ b/samples/domain_example.py
@@ -119,6 +119,9 @@ list_with_cf = {
         'name': 'ListWithConditionalFormats',
         'description': 'Test list',
         'fields': [{
+            'name': 'rowId',
+            'rangeURI': 'int'
+        }, {
             'name': 'date',
             'rangeURI': 'date',
             'conditionalFormats': [{
@@ -142,6 +145,10 @@ list_with_cf = {
                 'strikethrough': False
             }]
         }]
+    },
+    'options': {
+        'keyName': 'rowId',
+        'keyType': 'AutoIncrementInteger'
     }
 }
 
@@ -165,7 +172,7 @@ for field in domain_cf.fields:
 print('The filter on field "' + age_field.name + '" has been updated to: ' + age_field.conditional_formats[0].filter)
 
 ###################
-# Delete a domain's condtiional format
+# Delete a domain's conditional format
 ###################
 for field in domain_cf.fields:
     if field.name == 'age':

--- a/samples/domain_example.py
+++ b/samples/domain_example.py
@@ -16,6 +16,7 @@
 from __future__ import unicode_literals
 
 from labkey.utils import create_server_context
+from labkey.query import QueryFilter
 from labkey import domain
 
 labkey_server = 'localhost:8080'
@@ -108,3 +109,67 @@ if 'success' in drop_response:
 drop_response = domain.drop(server_context, 'lists', 'BloodTypes')
 if 'success' in drop_response:
     print('The list domain was deleted.')
+
+###################
+# Create a domain with a conditional format
+###################
+list_with_cf = {
+    'kind': 'IntList',
+    'domainDesign': {
+        'name': 'ListWithConditionalFormats',
+        'description': 'Test list',
+        'fields': [{
+            'name': 'date',
+            'rangeURI': 'date',
+            'conditionalFormats': [{
+                'filter': QueryFilter('date', '10/29/1995', QueryFilter.Types.DATE_GREATER_THAN,
+                                      '10/31/1995', QueryFilter.Types.DATE_LESS_THAN),
+                'textcolor': 'f44e3b',
+                'backgroundcolor': 'fcba03',
+                'bold': True,
+                'italic': False,
+                'strikethrough': False
+            }]
+        }, {
+            'name': 'age',
+            'rangeURI': 'int',
+            'conditionalFormats': [{
+                'filter': QueryFilter('age', 500, QueryFilter.Types.GREATER_THAN),
+                'textcolor': 'f44e3b',
+                'backgroundcolor': 'fcba03',
+                'bold': True,
+                'italic': True,
+                'strikethrough': False
+            }]
+        }]
+    }
+}
+
+domain_cf = domain.create(server_context, list_with_cf)
+
+###################
+# Edit an existing domain's conditional format
+###################
+age_field = list(filter(lambda domain_field: domain_field.name == 'age', domain_cf.fields))[0]
+print('The filter on field "' + age_field.name + '" was: ' + age_field.conditional_formats[0].filter)
+
+for field in domain_cf.fields:
+    if field.name == 'age':
+        cf = domain.conditional_format(filter='format.column~eq=30', text_color='ff0000')
+        field.conditional_formats = [cf]
+    if field.name == 'date':
+        cf = domain.conditional_format(filter=QueryFilter('date', "10/30/1995", QueryFilter.Types.DATE_LESS_THAN),
+                                       text_color='f44e3b')
+        field.conditional_formats = [cf]
+
+print('The filter on field "' + age_field.name + '" has been updated to: ' + age_field.conditional_formats[0].filter)
+
+###################
+# Delete a domain's condtiional format
+###################
+for field in domain_cf.fields:
+    if field.name == 'age':
+        field.conditional_formats = []
+
+# CLeanup
+domain.drop(server_context, 'lists', 'ListWithConditionalFormats')

--- a/samples/domain_example.py
+++ b/samples/domain_example.py
@@ -169,6 +169,7 @@ for field in domain_cf.fields:
                                        text_color='f44e3b')
         field.conditional_formats = [cf]
 
+domain.save(server_context, 'lists', 'ListWithConditionalFormats', domain_cf)
 print('The filter on field "' + age_field.name + '" has been updated to: ' + age_field.conditional_formats[0].filter)
 
 ###################

--- a/test/test_domain.py
+++ b/test/test_domain.py
@@ -26,6 +26,7 @@ except ImportError:
 
 from labkey import utils
 from labkey.domain import create, Domain, drop, get, infer_fields, save
+from labkey import domain
 from labkey.exceptions import RequestAuthorizationError
 from labkey.query import QueryFilter
 
@@ -305,7 +306,7 @@ class TestConditionalFormatSave(unittest.TestCase):
             'name': 'theKey',
             'rangeURI': 'int',
             'conditionalFormats': [{
-                'filter': Domain.get_filter_format(QueryFilter('theKey', 200, QueryFilter.Types.LESS_THAN)),
+                'filter': domain.get_filter_format(QueryFilter('theKey', 200, QueryFilter.Types.LESS_THAN)),
                 'textcolor': 'f44e3b',
                 'backgroundcolor': 'fcba03',
                 'bold': True,

--- a/test/test_domain.py
+++ b/test/test_domain.py
@@ -257,7 +257,7 @@ class TestConditionalFormatCreate(unittest.TestCase):
                     'name': 'theKey',
                     'rangeURI': 'int',
                     'conditionalFormats': [{
-                        'filter': QueryFilter('theKey', 500, QueryFilter.Types.GREATER_THAN).get_filter_format(),
+                        'filter': domain.get_filter_format(QueryFilter('theKey', 500, QueryFilter.Types.GREATER_THAN)),
                         'textcolor': 'f44e3b',
                         'backgroundcolor': 'fcba03',
                         'bold': True,

--- a/test/test_domain.py
+++ b/test/test_domain.py
@@ -305,7 +305,7 @@ class TestConditionalFormatSave(unittest.TestCase):
             'name': 'theKey',
             'rangeURI': 'int',
             'conditionalFormats': [{
-                'filter': QueryFilter('theKey', 200, QueryFilter.Types.LESS_THAN).get_filter_format(),
+                'filter': Domain.get_filter_format(QueryFilter('theKey', 200, QueryFilter.Types.LESS_THAN)),
                 'textcolor': 'f44e3b',
                 'backgroundcolor': 'fcba03',
                 'bold': True,

--- a/test/test_domain.py
+++ b/test/test_domain.py
@@ -25,12 +25,13 @@ except ImportError:
     import unittest.mock as mock
 
 from labkey import utils
-from labkey.domain import create, Domain, drop, get, infer_fields, save
-from labkey import domain
+from labkey.domain import create, conditional_format, Domain, drop, encode_conditional_format_filter, \
+    get, infer_fields, save
 from labkey.exceptions import RequestAuthorizationError
 from labkey.query import QueryFilter
 
-from .utilities import MockLabKey, mock_server_context, success_test, success_test_get, throws_error_test, throws_error_test_get
+from .utilities import MockLabKey, mock_server_context, success_test, success_test_get, throws_error_test, \
+    throws_error_test_get
 
 
 domain_controller = 'property'
@@ -245,11 +246,12 @@ class TestSave(unittest.TestCase):
         throws_error_test(test, RequestAuthorizationError, self.service.get_unauthorized_response(),
                           save, *self.args, **self.expected_kwargs)
 
+
 class TestConditionalFormatCreate(unittest.TestCase):
 
     def setUp(self):
 
-        domain_definition = {
+        self.domain_definition = {
             'kind': 'IntList',
             'domainDesign': {
                 'name': 'TheTestList_cf',
@@ -257,9 +259,9 @@ class TestConditionalFormatCreate(unittest.TestCase):
                     'name': 'theKey',
                     'rangeURI': 'int',
                     'conditionalFormats': [{
-                        'filter': domain.get_filter_format(QueryFilter('theKey', 500, QueryFilter.Types.GREATER_THAN)),
-                        'textcolor': 'f44e3b',
-                        'backgroundcolor': 'fcba03',
+                        'filter': encode_conditional_format_filter(QueryFilter('theKey', 500)),
+                        'textColor': 'f44e3b',
+                        'backgroundColor': 'fcba03',
                         'bold': True,
                         'italic': True,
                         'strikethrough': False
@@ -271,25 +273,25 @@ class TestConditionalFormatCreate(unittest.TestCase):
         class MockCreate(MockLabKey):
             api = 'createDomain.api'
             default_action = domain_controller
-            default_success_body = domain_definition
+            default_success_body = self.domain_definition
 
         self.service = MockCreate()
 
         self.expected_kwargs = {
             'expected_args': [self.service.get_server_url()],
-            'data': json.dumps(domain_definition),
+            'data': json.dumps(self.domain_definition),
             'headers': {'Content-Type': 'application/json'},
             'timeout': 300
         }
 
         self.args = [
-            mock_server_context(self.service), domain_definition
+            mock_server_context(self.service), self.domain_definition
         ]
 
     def test_success(self):
         test = self
         success_test(test, self.service.get_successful_response(),
-                     create, False,  *self.args, **self.expected_kwargs)
+                     create, False, *self.args, **self.expected_kwargs)
 
     def test_unauthorized(self):
         test = self
@@ -298,27 +300,44 @@ class TestConditionalFormatCreate(unittest.TestCase):
 
 
 class TestConditionalFormatSave(unittest.TestCase):
-    domain = Domain(**{
-        'container': 'TestContainer',
-        'description': 'A Test Domain',
-        'domain_id': 5314,
-        'fields': [{
-            'name': 'theKey',
-            'rangeURI': 'int',
-            'conditionalFormats': [{
-                'filter': domain.get_filter_format(QueryFilter('theKey', 200, QueryFilter.Types.LESS_THAN)),
-                'textcolor': 'f44e3b',
-                'backgroundcolor': 'fcba03',
-                'bold': True,
-                'italic': True,
-                'strikethrough': True
-            }]
-        }]
-    })
+
     schema_name = 'lists'
     query_name = 'TheTestList_cf'
 
     def setUp(self):
+        self.test_domain = Domain(**{
+            'container': 'TestContainer',
+            'description': 'A Test Domain',
+            'domain_id': 5314,
+            'fields': [{
+                'name': 'theKey',
+                'rangeURI': 'int'
+            }]
+        })
+
+        self.test_domain.fields[0].conditional_formats = [
+            # create conditional format using our utility for a QueryFilter
+            conditional_format(
+                background_color='fcba03',
+                bold=True,
+                italic=True,
+                query_filter=QueryFilter('theKey', 200),
+                strike_through=True,
+                text_color='f44e3b',
+            ),
+            # create conditional format using our utility for a QueryFilter list
+            conditional_format(
+                background_color='fcba03',
+                bold=True,
+                italic=True,
+                query_filter=[
+                    QueryFilter('theKey', 500, QueryFilter.Types.GREATER_THAN),
+                    QueryFilter('theKey', 1000, QueryFilter.Types.LESS_THAN)
+                ],
+                strike_through=True,
+                text_color='f44e3b',
+            )
+        ]
 
         class MockSave(MockLabKey):
             api = 'saveDomain.api'
@@ -328,7 +347,7 @@ class TestConditionalFormatSave(unittest.TestCase):
         self.service = MockSave()
 
         payload = {
-            'domainDesign': self.domain.to_json(),
+            'domainDesign': self.test_domain.to_json(),
             'queryName': self.query_name,
             'schemaName': self.schema_name
         }
@@ -341,18 +360,19 @@ class TestConditionalFormatSave(unittest.TestCase):
         }
 
         self.args = [
-            mock_server_context(self.service), self.schema_name, self.query_name, self.domain
+            mock_server_context(self.service), self.schema_name, self.query_name, self.test_domain
         ]
 
     def test_success(self):
         test = self
         success_test(test, self.service.get_successful_response(),
-                     save, True,  *self.args, **self.expected_kwargs)
+                     save, True, *self.args, **self.expected_kwargs)
 
     def test_unauthorized(self):
         test = self
         throws_error_test(test, RequestAuthorizationError, self.service.get_unauthorized_response(),
                           save, *self.args, **self.expected_kwargs)
+
 
 def suite():
     load_tests = unittest.TestLoader().loadTestsFromTestCase
@@ -361,7 +381,9 @@ def suite():
         load_tests(TestDrop),
         load_tests(TestGet),
         load_tests(TestInferFields),
-        load_tests(TestSave)
+        load_tests(TestSave),
+        load_tests(TestConditionalFormatCreate),
+        load_tests(TestConditionalFormatSave)
     ])
 
 


### PR DESCRIPTION
#### Rationale
We're including functionality on our Python API to allow conditional format definitions on fields to be created, removed, and updated, using QueryFilter for convenience in construction.

#### Changes
* domain.create() now iterates through its conditional formats and converts instances or lists of QueryFilter to their string format.
* domain.conditional_format() provides a wrapper for creating a conditional format--typically to be used in updating
* Tests and example code added 

#### Notes
We talked about how the helper function domain.conditional_format() could be replaced with a direct call to ConditionalFormat, but the inclusion of the helper function was preferred.