### PR TITLE
Issue 36474 - add support for ignoreFilter to select_rows

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,13 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 1.4.0 package
+==============================
+
+*Release date: 06/17/2020*
+
+- Add ignore_filter option to select_rows
+
 What's New in the LabKey 1.3.0 package
 ==============================
 

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -16,6 +16,6 @@
 from labkey import domain, query, experiment, security, utils
 
 __title__ = 'labkey'
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 __author__ = 'LabKey'
 __license__ = 'Apache License 2.0'

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -201,7 +201,8 @@ def select_rows(server_context, schema_name, query_name, view_name=None,
                 include_update_column=None,
                 selection_key=None,
                 required_version=None,
-                timeout=_default_timeout
+                timeout=_default_timeout,
+                ignore_filter=None,
                 ):
     """
     Query data from a LabKey server
@@ -225,6 +226,7 @@ def select_rows(server_context, schema_name, query_name, view_name=None,
     :param selection_key:
     :param required_version: decimal value that indicates the response version of the api
     :param timeout: Request timeout in seconds (defaults to 30s)
+    :param ignore_filter: Boolean, if true, the command will ignore any filter that may be part of the chosen view.
     :return:
     """
     url = server_context.build_url('query', 'getQuery.api', container_path=container_path)
@@ -282,6 +284,9 @@ def select_rows(server_context, schema_name, query_name, view_name=None,
 
     if required_version is not None:
         payload['apiVersion'] = required_version
+
+    if ignore_filter is not None and ignore_filter is True:
+        payload['query.ignoreFilter'] = 1
 
     return server_context.make_request(url, payload, timeout=timeout)
 


### PR DESCRIPTION
#### Rationale
Our Python API doesn't allow you to pass ignoreFilter to the server.

#### Related Pull Requests
* n/a

#### Changes
* Add ignore_filter param to select_rows method
* Bumped version to 1.4.0
