### PR TITLE
Issue42489: Bug With experiment.save_batch

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,13 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 2.0.1 package
+==============================
+
+*Release date: 02/01/2021*
+- Updated Run.to_json() to drop unset values, since keys are given default values server-side, and null values on the
+form result in exceptions
+
 What's New in the LabKey 2.0.0 package
 ==============================
 

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -16,6 +16,6 @@
 from labkey import domain, query, experiment, security, utils
 
 __title__ = "labkey"
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/experiment.py
+++ b/labkey/experiment.py
@@ -103,7 +103,8 @@ class Run(ExpObject):
         data["materialOutputs"] = self.material_outputs
         data["plateMetadata"] = self.plate_metadata
 
-        # Issue42489: Only add class attributes of Run to json if they are truthy
+        # Issue 2489: Drop empty values. Server supplies default values for missing keys, 
+        # and will throw exception if a null value is supplied
         data = {k: v for k, v in data.items() if v}
         return data
 

--- a/labkey/experiment.py
+++ b/labkey/experiment.py
@@ -103,7 +103,7 @@ class Run(ExpObject):
         data["materialOutputs"] = self.material_outputs
         data["plateMetadata"] = self.plate_metadata
 
-        # Issue42489: Only add class attributes of Run (and not ExpObject) to json if they are truthy
+        # Issue42489: Only add class attributes of Run to json if they are truthy
         data = {k: v for k, v in data.items() if v}
         return data
 

--- a/labkey/utils.py
+++ b/labkey/utils.py
@@ -31,3 +31,8 @@ class DateTimeEncoder(json.JSONEncoder):
 def json_dumps(*args, **kwargs):
     kwargs.setdefault("cls", DateTimeEncoder)
     return json.dumps(*args, **kwargs)
+
+
+def snake_to_camel_case(name):
+    components = name.split('_')
+    return components[0] + ''.join(x.title() for x in components[1:])

--- a/labkey/utils.py
+++ b/labkey/utils.py
@@ -31,8 +31,3 @@ class DateTimeEncoder(json.JSONEncoder):
 def json_dumps(*args, **kwargs):
     kwargs.setdefault("cls", DateTimeEncoder)
     return json.dumps(*args, **kwargs)
-
-
-def snake_to_camel_case(name):
-    components = name.split('_')
-    return components[0] + ''.join(x.title() for x in components[1:])

--- a/test/unit/test_experiment_api.py
+++ b/test/unit/test_experiment_api.py
@@ -290,7 +290,7 @@ class TestSaveBatch(unittest.TestCase):
         self.service = MockSaveBatch()
         self.expected_kwargs = {
             "expected_args": [self.service.get_server_url()],
-            "data": '{"assayId": 12345, "batches": [{"batchProtocolId": null, "comment": null, "created": null, "createdBy": null, "modified": null, "modifiedBy": null, "name": null, "properties": {"PropertyName": "Property Value"}, "runs": [{"comment": null, "created": null, "createdBy": null, "dataInputs": [], "dataRows": [], "experiments": [], "filePathRoot": null, "materialInputs": [], "materialOutputs": [], "modified": null, "modifiedBy": null, "name": "python upload", "plateMetadata": null, "properties": {"RunFieldName": "Run Field Value"}}]}]}',
+            "data": '{"assayId": 12345, "batches": [{"batchProtocolId": null, "comment": null, "created": null, "createdBy": null, "modified": null, "modifiedBy": null, "name": null, "properties": {"PropertyName": "Property Value"}, "runs": [{"comment": null, "created": null, "createdBy": null, "dataInputs": [], "modified": null, "modifiedBy": null, "name": "python upload", "properties": {"RunFieldName": "Run Field Value"}}]}]}',
             "headers": {"Content-type": "application/json", "Accept": "text/plain"},
             "timeout": 300,
         }

--- a/test/unit/test_experiment_api.py
+++ b/test/unit/test_experiment_api.py
@@ -290,7 +290,7 @@ class TestSaveBatch(unittest.TestCase):
         self.service = MockSaveBatch()
         self.expected_kwargs = {
             "expected_args": [self.service.get_server_url()],
-            "data": '{"assayId": 12345, "batches": [{"batchProtocolId": null, "comment": null, "created": null, "createdBy": null, "modified": null, "modifiedBy": null, "name": null, "properties": {"PropertyName": "Property Value"}, "runs": [{"comment": null, "created": null, "createdBy": null, "dataInputs": [], "modified": null, "modifiedBy": null, "name": "python upload", "properties": {"RunFieldName": "Run Field Value"}}]}]}',
+            "data": '{"assayId": 12345, "batches": [{"batchProtocolId": null, "comment": null, "created": null, "createdBy": null, "modified": null, "modifiedBy": null, "name": null, "properties": {"PropertyName": "Property Value"}, "runs": [{"name": "python upload", "properties": {"RunFieldName": "Run Field Value"}}]}]}',
             "headers": {"Content-type": "application/json", "Accept": "text/plain"},
             "timeout": 300,
         }


### PR DESCRIPTION
#### Rationale
As described on the Issue, falsey values that are being passed within the form  `save_batch()` sends are blowing up when the server-side code attempts to pull JSONObjects out of null. Since defaults are applied when form attributes are not supplied, one solution is to strip out falsey values in the `to_json()` within the API.

I've verified locally that this works. 

I might also have ridiculously overengineered this through my desire to dynamically grab attribute items on `Run` to avoid a
`if self.file_path_root:
    data["filePathRoot"] = self.file_path_root` repeat x8 times type of situation. Let me know your thoughts on the approach here.

#### Related Pull Requests
* n/a

#### Changes
* Strip out falsey attribute values in `to_json()` of `Run`
* Update expected response upon hitting `save_batch()` within tests
