### PR TITLE
Update gitignore & setup.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ labkey\.egg-info/
 .idea/
 *.iml
 *.swp
+
+.DS_Store
+.python-version

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,3 @@ test=pytest
 [coverage:html]
 directory = build/coverage_html
 title = Test coverage report for labkey
-
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
#### Rationale
The .gitignore did not include `.DS_Store` files which is annoying for mac users, or `.python-version` which is necessary for pyenv users. We also do not want to release universal wheels anymore, so it doesn't make sense to default to them when running bdist_wheel. These changes will not require a new release.

#### Related Pull Requests
* n/a
#### Changes
* .gitignore: Add .DS_Store and .python-version files
* Remove universal flag from setup.cfg bdist_wheel entry
