### PR TITLE
Add ontology filters to QueryFilter.Types

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,12 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 2.1.0 package
+==============================
+
+*Release date: TBD*
+Adding support for ontology based column filters ONTOLOGY_IN_SUBTREE and ONTOLOGY_NOT_IN_SUBTREE
+
 What's New in the LabKey 2.0.1 package
 ==============================
 

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -16,6 +16,6 @@
 from labkey import domain, query, experiment, security, utils
 
 __title__ = "labkey"
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -130,6 +130,9 @@ class QueryFilter:
         IS_BLANK = "isblank"
         IS_NOT_BLANK = "isnonblank"
 
+        ONTOLOGY_IN_SUBTREE = "concept:insubtree"
+        ONTOLOGY_NOT_IN_SUBTREE = "concept:notinsubtree"
+
         MEMBER_OF = "memberof"
 
     def __init__(self, column, value, filter_type=Types.EQUAL):


### PR DESCRIPTION
#### Rationale
Item #8670 - https://docs.google.com/document/d/1QmHYktA4uNPxiSeid1kX2TakE2E0QPU4ZBkuSwTNeZI/edit?usp=sharing
Ontology, data region column filtering

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2205

#### Changes
* Added Filter.Types.ONTOLOGY_NOT_IN_SUBTREE and Filter.Types.ONTOLOGY_IN_SUBTREE
