### PR TITLE
Fix issue 43337

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,10 +2,16 @@
 LabKey Python Client API News
 +++++++++++
 
-What's New in the LabKey 2.1.0 package
+What's New in the LabKey 2.1.1 package
 ==============================
 
 *Release date: TBD*
+- Fix issue with domain.create raising exception when attempting to create a domain from a template
+
+What's New in the LabKey 2.1.0 package
+==============================
+
+*Release date: 05/12/2021*
 - Add support for ontology based column filters ONTOLOGY_IN_SUBTREE and ONTOLOGY_NOT_IN_SUBTREE
 - ServerContext.make_request: payload is now optional
 - ServerContext.make_request: add json kwarg

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -5,8 +5,8 @@ LabKey Python Client API News
 What's New in the LabKey 2.1.1 package
 ==============================
 
-*Release date: TBD*
-- Fix issue with domain.create raising exception when attempting to create a domain from a template
+*Release date: 06/23/2021*
+- Fix issue with domain.create raising exception when attempting to create a domain from a template (Issue 43337)
 
 What's New in the LabKey 2.1.0 package
 ==============================

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -16,6 +16,6 @@
 from labkey import domain, query, experiment, security, utils
 
 __title__ = "labkey"
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/domain.py
+++ b/labkey/domain.py
@@ -390,10 +390,14 @@ def create(
     """
     url = server_context.build_url("property", "createDomain.api", container_path=container_path)
     domain = None
-    domain_fields = domain_definition["domainDesign"]["fields"]
-    domain_definition["domainDesign"]["fields"] = list(
-        map(__format_conditional_filters, domain_fields)
-    )
+
+    # domainDesign is not required when creating a domain from a template
+    if domain_definition["domainDesign"] is not None:
+        domain_fields = domain_definition["domainDesign"]["fields"]
+        domain_definition["domainDesign"]["fields"] = list(
+            map(__format_conditional_filters, domain_fields)
+        )
+    
     raw_domain = server_context.make_request(url, json=domain_definition)
 
     if raw_domain is not None:


### PR DESCRIPTION
#### Rationale
The Python client throws an error if you attempt to create a domain from a template because you don't pass a domain definition with a "domainDesign". This PR does a None check for "domainDesign" before attempting to format conditional filters.

#### Related Pull Requests
* n/a

#### Changes
* Make "domainDesign" optional when calling domain.create (Fixes issue 43337)
