### PR TITLE
Update supported versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ else:
 ```
 
 ## Supported Versions
-Python 3.6+ is fully supported.
+Python 3.7+ is fully supported.
 LabKey Server v15.1 and later.
 
 ## Contributing


### PR DESCRIPTION
#### Rationale
The README lists Python support for version 3.6+, but we use dataclasses which are available in versions 3.7+

#### Related Pull Requests
* n/a

#### Changes
* Update README to indicate we support Python 3.7+
