### PR TITLE
Add support for creating Freezer Manager freezer hierarchies via StorageController APIs

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -1,6 +1,14 @@
 +++++++++++
 LabKey Python Client API News
 +++++++++++
+What's New in the LabKey 2.4.0 package
+==============================
+
+*Release date: TBD*
+- Add support for creating Freezer Manager freezer hierarchies via StorageController APIs
+  - earliest compatible LabKey Server version: 22.10.0
+  - StorageWrapper: create_storage_item, update_storage_item, delete_storage_item
+
 What's New in the LabKey 2.3.0 package
 ==============================
 

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -4,7 +4,7 @@ LabKey Python Client API News
 What's New in the LabKey 2.4.0 package
 ==============================
 
-*Release date: TBD*
+*Release date: 09/21/2022*
 - Add support for creating Freezer Manager freezer hierarchies via StorageController APIs
   - earliest compatible LabKey Server version: 22.10.0
   - StorageWrapper: create_storage_item, update_storage_item, delete_storage_item

--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ Security API - [sample code](samples/security_example.py)
 
 - Available for administrating and configuring user accounts and permissions.
 
-WebDav
+Storage API - [docs](docs/storage.md) 
 
-- Documentation and example code can be found [here](docs/webdav.md).
+- Create, update, or delete a LabKey Freezer Manager storage item.
+
+WebDav - [docs](docs/webdav.md)
+
+- Convenience methods for creating "webdavclient3" clients and building webdav file paths.
 
 ## Installation
 To install, simply use `pip`:

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -4,7 +4,7 @@ Create, update, or delete a LabKey Freezer Manager storage item.
 
 Storage items can be used in the creation of a freezer hierarchy. Freezer hierarchies consist of a top level Freezer, 
 which can have any combination of child non-terminal storage locations (i.e. those that do not directly contain samples 
-but can contain other units) and terminal storage locations (i.e. units in the freezer which directly contain samples 
+but can contain other units) and terminal storage locations (i.e. units in the freezer that directly contain samples 
 and cannot contain other units).
 
 Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister, Storage Unit Type, or 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,132 @@
+# LabKey Storage API Support
+
+Create, update, or delete a LabKey Freezer Manager storage item. 
+
+Storage items can be used in the creation of a freezer hierarchy. Freezer hierarchies consist of a top level Freezer, 
+which can have any combination of child non-terminal storage locations (i.e. those that do not directly contain samples 
+but can contain other units) and terminal storage locations (i.e. units in the freezer which directly contain samples 
+and cannot contain other units).
+
+Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister, Storage Unit Type, or 
+Terminal Storage Location.
+
+The specific set of props will differ for each storage item type:
+- Physical Location: name, description, locationId (rowId of the parent Physical Location)
+- Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status
+- Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)
+- Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")
+- Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)
+
+### Installation and Setup for the LabKey Python API:
+- https://github.com/LabKey/labkey-api-python/blob/master/README.md
+
+### Additional details from Labkey Documentation:
+- https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=createFreezer
+- https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=freezerLocation
+
+### Examples
+
+```python
+from labkey.api_wrapper import APIWrapper
+
+labkey_server = "localhost:8080"
+project_name = "FM API Test"  # Project folder name
+contextPath = "labkey"
+api = APIWrapper(labkey_server, project_name, contextPath, use_ssl=False)
+
+
+###############
+# Create a freezer with two shelves
+###############
+result = api.storage.create_storage_item(
+    "Freezer",
+    {
+        "name": "Freezer #1",
+        "description": "Test freezer from API",
+        "serialNumber": "ABC123",
+        "status": "Active",
+    },
+)
+if result is not None:
+    print(result)
+else:
+    print("Create freezer: no results returned")
+    exit()
+freezer_row_id = result["data"]["rowId"]
+
+result = api.storage.create_storage_item(
+    "Shelf",
+    {
+        "name": "Shelf #1",
+        "description": "This shelf is for samples from Lab A.",
+        "locationId": freezer_row_id,
+    },
+)
+if result is not None:
+    print(result)
+else:
+    print("Create shelf: no results returned")
+    exit()
+shelf1_row_id = result["data"]["rowId"]
+
+result = api.storage.create_storage_item(
+    "Shelf",
+    {
+        "name": "Shelf #2",
+        "description": "This shelf is for samples from Lab B.",
+        "locationId": freezer_row_id,
+    },
+)
+if result is not None:
+    print(result)
+else:
+    print("Create shelf: no results returned")
+    exit()
+shelf2_row_id = result["data"]["rowId"]
+
+###############
+# Create a terminal storage location in the freezer
+###############
+result = api.storage.create_storage_item(
+    "Storage Unit Type", {"name": "10 X 10 Box", "unitType": "Box", "rows": 10, "cols": 10}
+)
+if result is not None:
+    print(result)
+else:
+    print("Create storage unit type: no results returned")
+    exit()
+box_type_id = result["data"]["rowId"]
+
+result = api.storage.create_storage_item(
+    "Terminal Storage Location",
+    {"name": "Box #1", "typeId": box_type_id, "locationId": shelf1_row_id},
+)
+if result is not None:
+    print(result)
+else:
+    print("Create box: no results returned")
+    exit()
+box_id = result["data"]["rowId"]
+
+###############
+# Update the location of a box in the freezer
+###############
+result = api.storage.update_storage_item(
+    "Terminal Storage Location", {"rowId": box_id, "locationId": shelf2_row_id}
+)
+if result is not None:
+    print(result)
+else:
+    print("Update box: no results returned")
+    exit()
+
+###############
+# Delete the freezer, which will delete the full hierarchy of non-terminal and terminal storage locations
+###############
+result = api.storage.delete_storage_item("Freezer", freezer_row_id)
+if result is not None:
+    print(result)
+else:
+    print("Delete freezer: no results returned")
+    exit()
+```

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -16,6 +16,6 @@
 from labkey import domain, query, experiment, security, utils
 
 __title__ = "labkey"
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/api_wrapper.py
+++ b/labkey/api_wrapper.py
@@ -3,6 +3,7 @@ from .domain import DomainWrapper
 from .experiment import ExperimentWrapper
 from .query import QueryWrapper
 from .security import SecurityWrapper
+from .storage import StorageWrapper
 from .server_context import ServerContext
 
 
@@ -36,3 +37,4 @@ class APIWrapper:
         self.experiment = ExperimentWrapper(self.server_context)
         self.query = QueryWrapper(self.server_context)
         self.security = SecurityWrapper(self.server_context)
+        self.storage = StorageWrapper(self.server_context)

--- a/labkey/storage.py
+++ b/labkey/storage.py
@@ -25,7 +25,7 @@ DESCRIPTION:
 Create, update, or delete a LabKey Freezer Manager storage item. Storage items can be used in the creation of a
 freezer hierarchy. Freezer hierarchies consist of a top level Freezer, which can have any combination of child
 non-terminal storage locations (i.e. those that do not directly contain samples but can contain other units) and
-terminal storage locations (i.e. units in the freezer which directly contain samples and cannot contain other units).
+terminal storage locations (i.e. units in the freezer that directly contain samples and cannot contain other units).
 
 Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister, Storage Unit Type, or Terminal Storage Location.
 The specific set of props will differ for each storage item type:
@@ -95,6 +95,7 @@ def delete_storage_item(
     """
     Delete an existing LabKey Freezer Manager storage item. Note that deletion of freezers or locations within the
     freezer hierarchy will cascade the delete down the hierarchy to remove child locations and terminal storage locations.
+    Samples in the deleted freezer location(s) will not be deleted but will be removed from storage.
     :param server_context: A LabKey server context. See utils.create_server_context.
     :param type:
     :param row_id:

--- a/labkey/storage.py
+++ b/labkey/storage.py
@@ -1,0 +1,128 @@
+#
+# Copyright (c) 2017-2018 LabKey Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+############################################################################
+NAME:
+LabKey Storage API
+
+SUMMARY:
+This module provides functions for interacting with storage items on a LabKey Server.
+
+DESCRIPTION:
+Create, update, or delete a LabKey Freezer Manager storage item. Storage items can be used in the creation of a
+freezer hierarchy. Freezer hierarchies consist of a top level Freezer, which can have any combination of child
+non-terminal storage locations (i.e. those that do not directly contain samples but can contain other units) and
+terminal storage locations (i.e. units in the freezer which directly contain samples and cannot contain other units).
+
+Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister, Storage Unit Type, or Terminal Storage Location.
+The specific set of props will differ for each storage item type:
+ - Physical Location: name, description, locationId (rowId of the parent Physical Location)
+ - Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status
+ - Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)
+ - Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")
+ - Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)
+
+Installation and Setup for the LabKey Python API:
+https://github.com/LabKey/labkey-api-python/blob/master/README.md
+
+Additional details from Labkey Documentation:
+https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=createFreezer
+https://www.labkey.org/SampleManagerHelp/wiki-page.view?name=freezerLocation
+
+############################################################################
+"""
+import functools
+from dataclasses import dataclass
+
+from typing import Union, List
+
+from labkey.server_context import ServerContext
+
+STORAGE_CONTROLLER = "storage"
+
+
+def create_storage_item(
+    server_context: ServerContext, type: str, props: dict, container_path: str = None
+):
+    """
+    Create a new LabKey Freezer Manager storage item that can be used in the creation of a freezer hierarchy.
+    :param server_context: A LabKey server context. See utils.create_server_context.
+    :param type:
+    :param props:
+    :param container_path:
+    :return:
+    """
+    url = server_context.build_url(STORAGE_CONTROLLER, "create.api", container_path)
+    payload = {"type": type, "props": props}
+
+    return server_context.make_request(url, json=payload)
+
+
+def update_storage_item(
+    server_context: ServerContext, type: str, props: dict, container_path: str = None
+):
+    """
+    Update an existing LabKey Freezer Manager storage item to change its properties or location within the freezer hierarchy.
+    For update_storage_item, the "rowId" primary key value is required to be set within the props.
+    :param server_context: A LabKey server context. See utils.create_server_context.
+    :param type:
+    :param props:
+    :param container_path:
+    :return:
+    """
+    url = server_context.build_url(STORAGE_CONTROLLER, "update.api", container_path)
+    payload = {"type": type, "props": props}
+
+    return server_context.make_request(url, json=payload)
+
+
+def delete_storage_item(
+    server_context: ServerContext, type: str, row_id: int, container_path: str = None
+):
+    """
+    Delete an existing LabKey Freezer Manager storage item. Note that deletion of freezers or locations within the
+    freezer hierarchy will cascade the delete down the hierarchy to remove child locations and terminal storage locations.
+    :param server_context: A LabKey server context. See utils.create_server_context.
+    :param type:
+    :param row_id:
+    :param container_path:
+    :return:
+    """
+    url = server_context.build_url(STORAGE_CONTROLLER, "delete.api", container_path)
+    payload = {"type": type, "props": {"rowId": row_id}}
+
+    return server_context.make_request(url, json=payload)
+
+
+class StorageWrapper:
+    """
+    Wrapper for all of the API methods exposed in the storage module. Used by the APIWrapper class.
+    """
+
+    def __init__(self, server_context: ServerContext):
+        self.server_context = server_context
+
+    @functools.wraps(create_storage_item)
+    def create_storage_item(self, type: str, props: dict, container_path: str = None):
+        return create_storage_item(self.server_context, type, props, container_path)
+
+    @functools.wraps(update_storage_item)
+    def update_storage_item(self, type: str, props: dict, container_path: str = None):
+        return update_storage_item(self.server_context, type, props, container_path)
+
+    @functools.wraps(delete_storage_item)
+    def delete_storage_item(self, type: str, row_id: int, container_path: str = None):
+        return delete_storage_item(self.server_context, type, row_id, container_path)


### PR DESCRIPTION
#### Rationale
In the related PR for this epic we added a new StorageController with actions for create/update/delete of freezer hierarchy items (i.e. freezer physical locations, freezers, locations within the freezer, storage unit types, and terminal storage locations). This PR adds a new namespace (storage) to the Python API with commands for calling those StorageController actions: create_storage_item, update_storage_item, delete_storage_item.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/542

#### Changes
* StorageWrapper: create_storage_item, update_storage_item, delete_storage_item
* docs/storage.md with info and examples