### PR TITLE
Add user agent header to requests

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -8,6 +8,7 @@ What's New in the LabKey 2.4.0 package
 - Add support for creating Freezer Manager freezer hierarchies via StorageController APIs
   - earliest compatible LabKey Server version: 22.10.0
   - StorageWrapper: create_storage_item, update_storage_item, delete_storage_item
+- Set User-Agent header for requests to "LabKey Python API/<version>"
 
 What's New in the LabKey 2.3.0 package
 ==============================

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from labkey import domain, query, experiment, security, utils
-
 __title__ = "labkey"
 __version__ = "2.4.0"
 __author__ = "LabKey"

--- a/labkey/server_context.py
+++ b/labkey/server_context.py
@@ -1,4 +1,5 @@
 from labkey.utils import json_dumps
+from . import __version__
 import requests
 from requests.exceptions import RequestException
 from labkey.exceptions import (
@@ -70,6 +71,7 @@ class ServerContext:
         self._api_key = api_key
         self._disable_csrf = disable_csrf
         self._session = requests.Session()
+        self._session.headers.update({"User-Agent": f"LabKey Python API/{__version__}"})
 
         if self._use_ssl:
             self._scheme = "https://"


### PR DESCRIPTION
#### Rationale
This PR fixes [Issue 45891](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45891)

#### Related Pull Requests
* N/A

#### Changes
- Set User-Agent header for requests to `LabKey Python API/<version>`
