### PR TITLE
adding helper function to utils.py

### DIFF
--- a/labkey/utils.py
+++ b/labkey/utils.py
@@ -31,3 +31,44 @@ class DateTimeEncoder(json.JSONEncoder):
 def json_dumps(*args, **kwargs):
     kwargs.setdefault("cls", DateTimeEncoder)
     return json.dumps(*args, **kwargs)
+
+
+def transform_helper(userTransformFunc, filePathRunProperties):
+    #filePathRunProperties must be explicitly defined as ${runInfo} within the user's transform script
+    #parse run properties to for results data in and out filepaths
+    filePathIn = ''
+    filePathOut = ''
+    fileRunProperties = open(filePathRunProperties) 
+    for l in fileRunProperties:
+        row = l.strip().split('\t')
+        if row[0] == 'runDataFile':
+            filePathIn = row[1]
+            filePathOut = row[3]
+    fileRunProperties.close()
+    
+    #parse results data into array, confirming supported file type is used
+    fileIn = open(filePathIn)
+    dataGrid = []
+    
+    for l in fileIn:
+        if '\t' in l:
+            row = l.replace('\n', '').split('\t')
+        elif ',' in l:
+            row = l.replace('\n', '').split(',')
+        else:
+            raise ValueError('Unsupported file type or delimiter used. Header used: \n' + str(l))
+        dataGrid.append(row)    
+    fileIn.close()
+    
+    #run user transform on parsed results data array
+    transformedGrid = userTransformFunc(dataGrid)
+    
+    #write transformed results data array to LabKey assay results data grid
+    #transformed array must be a python list object, not a numpy array or pandas dataframe
+    fileOut = open(filePathOut, mode='w')
+    for row in transformedGrid:
+        row = [str(el).strip() for el in row]
+        row = '\t'.join(row)        
+        fileOut.write(row + '\n')
+    
+    fileOut.close()

--- a/samples/assay_transform_function_example.py
+++ b/samples/assay_transform_function_example.py
@@ -1,0 +1,22 @@
+# Import the transform helper from the labkey python api library
+from labkey.utils import transform_helper
+
+# the run properties filepath must be defined in this way so that it can be fed into the transform helper
+filepath = '${runInfo}'
+
+# define the function that you are using to transform your results data array
+def transform(grid):
+    isHeaderChecked = False    
+    # iterate through the rows of your results data, checking for the header
+    for row in grid:
+        if isHeaderChecked == False:
+            row.append('averageResult')
+            isHeaderChecked = True
+        else:
+            # In this example, we are taking the average of the 3rd-5th column values by row and appending that average value in a 6th column called "averageResult"
+            newValTemp = sum([float(val) for val in row[2:]])/len(row[2:])
+            row.append(round(newValTemp, 2))
+    return grid
+
+#call the transform helper using your user-defined transform function and the run properties filepath
+transform_helper(transform, filepath)


### PR DESCRIPTION
The helper function parses the run properties and results data so that the user doesn't need to include any parsing script in their transform script. The helper function only accepts a user-defined function that accepts an array of results data as its input and returns an array of results data matching the assay design it is used with. Also, the helper function requires that users explicitly define the run properties file path in their transform script, otherwise the labkey transform script parser does not recognize ${runInfo}.

#### Rationale
Users currently must write the parsing script for run properties and results data every time they make a transform script for assays. Because the parsing script will almost always be the same, this helper function can be used to save users time instead.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* add helper function for parsing run properties and results-level data in an assay transform script.
