### PR TITLE
Remove apikey prefix for webdav clients using api keys

### DIFF
--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 __title__ = "labkey"
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/server_context.py
+++ b/labkey/server_context.py
@@ -143,7 +143,7 @@ class ServerContext:
 
         if self._api_key is not None:
             options["webdav_login"] = "apikey"
-            options["webdav_password"] = f"apikey|{self._api_key}"
+            options["webdav_password"] = f"{self._api_key}"
 
         if webdav_options is not None:
             options = {


### PR DESCRIPTION
#### Rationale
We are no [longer requiring clients](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47514) use the "apikey|" prefix with their API Keys.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4177

#### Changes
* Remove `apikey|` prefix from webdav client configurations
