### PR TITLE
Issue 48298: Align API Filter Operators

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,12 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 2.6.0 package
+==============================
+
+*Release date: TBD*
+- Query API - add lineage-related filter types
+
 What's New in the LabKey 2.5.0 package
 ==============================
 

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -5,7 +5,7 @@ LabKey Python Client API News
 What's New in the LabKey 2.6.0 package
 ==============================
 
-*Release date: TBD*
+*Release date: 08/17/2023*
 - Query API - add lineage-related filter types
 
 What's New in the LabKey 2.5.0 package

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 __title__ = "labkey"
-__version__ = "2.5.1"
+__version__ = "2.6.0"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -77,8 +77,7 @@ class QueryFilter:
         Enumeration of acceptable filter types
         """
 
-        HAS_ANY_VALUE = ""
-
+        # These operators require a data value
         EQUAL = "eq"
         DATE_EQUAL = "dateeq"
 
@@ -124,13 +123,28 @@ class QueryFilter:
         BETWEEN = "between"
         NOT_BETWEEN = "notbetween"
 
+        MEMBER_OF = "memberof"
+
+        # These are the "no data value" operators
+        HAS_ANY_VALUE = ""
+
         IS_BLANK = "isblank"
         IS_NOT_BLANK = "isnonblank"
 
+        HAS_MISSING_VALUE = "hasmvvalue"
+        DOES_NOT_HAVE_MISSING_VALUE = "nomvvalue"
+
+        # Table/Query-wise operators
+        Q = "q"
+
+        # Ontology operators
         ONTOLOGY_IN_SUBTREE = "concept:insubtree"
         ONTOLOGY_NOT_IN_SUBTREE = "concept:notinsubtree"
 
-        MEMBER_OF = "memberof"
+        # Lineage operators
+        EXP_CHILD_OF = "exp:childof"
+        EXP_PARENT_OF = "exp:parentof"
+        EXP_LINEAGE_OF = "exp:lineageof"
 
     def __init__(self, column, value, filter_type=Types.EQUAL):
         self.column_name = column


### PR DESCRIPTION
#### Rationale
In the process of adding lineage filter operators to the APIs, I noticed a handful of inconsistencies I'm resolving across the APIs. See related pull requests.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-python/pull/61
* https://github.com/LabKey/labkey-api-js/pull/157
* https://github.com/LabKey/labkey-api-r/pull/95
* https://github.com/LabKey/labkey-api-java/pull/60

#### Changes
* Add the following operators:
    * HAS_MISSING_VALUE
    * DOES_NOT_HAVE_MISSING_VALUE
    * Q
    * EXP_CHILD_OF
    * EXP_PARENT_OF
    * EXP_LINEAGE_OF
* Add comments delineating operator types to align with other APIs
* Rearrange ordering of operator types to align with other APIs
* Update Change.txt
