### PR TITLE
Issue 48559: WAF encode parameters

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,14 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 2.6.2 package
+==============================
+
+*Release date: 12/14/2023*
+- Query API - WAF encode "sql" parameter for execute_sql
+    - WAF encoding of parameters is initially supported with LabKey Server v23.09
+    - WAF encoding can be opted out of on execute_sql calls by specifying waf_encode_sql=False
+
 What's New in the LabKey 2.6.1 package
 ==============================
 

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,7 +2,7 @@
 LabKey Python Client API News
 +++++++++++
 
-What's New in the LabKey 2.6.2 package
+What's New in the LabKey 3.0.0 package
 ==============================
 
 *Release date: 12/14/2023*

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 __title__ = "labkey"
-__version__ = "2.6.2"
+__version__ = "3.0.0"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 __title__ = "labkey"
-__version__ = "2.6.1"
+__version__ = "2.6.2"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -44,6 +44,7 @@ import functools
 from typing import List
 
 from .server_context import ServerContext
+from .utils import waf_encode
 
 _default_timeout = 60 * 5  # 5 minutes
 
@@ -231,6 +232,7 @@ def execute_sql(
     parameters: dict = None,
     required_version: float = None,
     timeout: int = _default_timeout,
+    waf_encode_sql: bool = True
 ):
     """
     Execute sql query against a LabKey server.
@@ -248,11 +250,12 @@ def execute_sql(
     :param parameters: parameter values to pass through to a parameterized query
     :param required_version: Api version of response
     :param timeout: timeout of request in seconds (defaults to 30s)
+    :param waf_encode_sql: WAF encode sql in request (defaults to True)
     :return:
     """
     url = server_context.build_url("query", "executeSql.api", container_path=container_path)
 
-    payload = {"schemaName": schema_name, "sql": sql}
+    payload = {"schemaName": schema_name, "sql": waf_encode(sql) if waf_encode_sql else sql}
 
     if container_filter is not None:
         payload["containerFilter"] = container_filter
@@ -484,6 +487,7 @@ class QueryWrapper:
         parameters: dict = None,
         required_version: float = None,
         timeout: int = _default_timeout,
+        waf_encode_sql: bool = True
     ):
         return execute_sql(
             self.server_context,
@@ -498,6 +502,7 @@ class QueryWrapper:
             parameters,
             required_version,
             timeout,
+            waf_encode_sql
         )
 
     @functools.wraps(insert_rows)

--- a/labkey/utils.py
+++ b/labkey/utils.py
@@ -16,6 +16,8 @@
 import json
 from functools import wraps
 from datetime import date, datetime
+from base64 import b64encode
+from urllib import parse
 
 
 # Issue #14: json.dumps on datetime throws TypeError
@@ -71,3 +73,21 @@ def transform_helper(user_transform_func, file_path_run_properties):
             row = [str(el).strip() for el in row]
             row = "\t".join(row)
             file_out.write(row + "\n")
+
+
+def btoa(value: str) -> str:
+    if not value:
+        return value
+    binary = value.encode("utf-8")
+    return b64encode(binary).decode()
+
+
+def encode_uri_component(value: str) -> str:
+    # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+    return parse.quote(value, encoding="utf-8", safe="-_.!~*'()")
+
+
+def waf_encode(value: str) -> str:
+    if value:
+        return "/*{{base64/x-www-form-urlencoded/wafText}}*/" + btoa(encode_uri_component(value))
+    return value

--- a/test/integration/test_query.py
+++ b/test/integration/test_query.py
@@ -101,6 +101,14 @@ def test_create_qc_state_definition(qc_states):
     assert qc_states["rows"][1]["label"] == "approved"
 
 
+def test_execute_sql(api: APIWrapper):
+    resp = api.query.execute_sql("core", "SELECT userId FROM core.users LIMIT 1")
+    assert resp["schemaName"] == "core"
+    assert resp["queryName"] == "sql"
+    assert resp["rowCount"] > 0
+    assert len(resp["rows"]) > 0
+
+
 def test_update_qc_state_definition(api: APIWrapper, qc_states, study):
     new_description = "for sure that is not right"
     edit_rowid = qc_states["rows"][0]["rowid"]

--- a/test/unit/test_query_api.py
+++ b/test/unit/test_query_api.py
@@ -31,6 +31,7 @@ from labkey.exceptions import (
     ServerNotFoundError,
     RequestAuthorizationError,
 )
+from labkey.utils import waf_encode
 
 from .utilities import MockLabKey, mock_server_context, success_test, throws_error_test
 
@@ -297,7 +298,7 @@ class TestExecuteSQL(unittest.TestCase):
         sql = "select * from " + schema + "." + query
         self.expected_kwargs = {
             "expected_args": [self.service.get_server_url()],
-            "data": {"sql": sql, "schemaName": schema},
+            "data": {"sql": waf_encode(sql), "schemaName": schema},
             "headers": None,
             "timeout": 300,
         }

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,0 +1,24 @@
+from labkey.utils import btoa, encode_uri_component, waf_encode
+
+
+def test_btoa():
+    assert btoa(None) is None
+    assert btoa("") == ""
+    assert btoa("DELETE TABLE some.table;") == "REVMRVRFIFRBQkxFIHNvbWUudGFibGU7"
+
+
+def test_encode_uri_component():
+    assert(
+        encode_uri_component("SELECT * FROM x.y WHERE y = 5 & 2 AND y IS NOT NULL;")
+        == "SELECT%20*%20FROM%20x.y%20WHERE%20y%20%3D%205%20%26%202%20AND%20y%20IS%20NOT%20NULL%3B"
+    )
+    assert encode_uri_component("><&/%' \"1äöüÅ") == "%3E%3C%26%2F%25'%20%221%C3%A4%C3%B6%C3%BC%C3%85"
+
+
+def test_waf_encode():
+    prefix = "/*{{base64/x-www-form-urlencoded/wafText}}*/"
+    assert waf_encode(None) is None
+    assert waf_encode("") == ""
+    assert waf_encode("hello") == prefix + "aGVsbG8="
+    assert waf_encode("DELETE TABLE some.table;") == prefix + "REVMRVRFJTIwVEFCTEUlMjBzb21lLnRhYmxlJTNC"
+    assert waf_encode("><&/%' \"1äöüÅ") == prefix + "JTNFJTNDJTI2JTJGJTI1JyUyMCUyMjElQzMlQTQlQzMlQjYlQzMlQkMlQzMlODU="


### PR DESCRIPTION
#### Rationale
This adds WAF encoding support which assists with obfuscating content that's often intercepted by web application firewalls that are scanning for likely SQL or script injection.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4699

#### Changes
- Introduce utility `waf_encode()`
- Default `query.execute_sql()` to WAF encode the SQL parameter. Method defaults to WAF encoding but this can be changed via the setting `waf_encode_sql=False`
- Add unit and integration test coverage
