### PR TITLE
set make_request timeout to 1800

### DIFF
--- a/labkey/server_context.py
+++ b/labkey/server_context.py
@@ -169,7 +169,7 @@ class ServerContext:
         url: str,
         payload: any = None,
         headers: dict = None,
-        timeout: int = 300,
+        timeout: int = 1800,
         method: str = "POST",
         non_json_response: bool = False,
         file_payload: any = None,


### PR DESCRIPTION
#### Rationale
A client is using an insert_rows call to jam the data from a 2GB TSV into LabKey, but it's failing with a 300 second timeout error. I am pretty certain that this default timeout is the issue. Because the timeout argument isn't passed along to the select_rows function, it seems easiest to just increase the timeout to a larger number. I assume 1800 seconds is sufficient, but we could obviously make the default timeout much longer if that makes more sense.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
