### PR TITLE
Issue 48490: Add auditing behavior param via new options param

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -6,7 +6,7 @@ What's New in the LabKey 3.1.0 package
 ==============================
 
 *Release date: TBD*
-- Query API - add optional parameters to insert_rows, select_rows, update_rows, and delete_rows
+- Query API - add optional parameters to insert_rows, update_rows, and delete_rows
 
 What's New in the LabKey 3.0.0 package
 ==============================

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,12 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 2.7.0 package
+==============================
+
+*Release date: TBD*
+- Query API - add options parameter to insert_rows, select_rows, and delete_rows
+
 What's New in the LabKey 2.6.0 package
 ==============================
 

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,12 +2,6 @@
 LabKey Python Client API News
 +++++++++++
 
-What's New in the LabKey 3.1.0 package
-==============================
-
-*Release date: TBD*
-- Query API - add optional parameters to insert_rows, update_rows, and delete_rows
-
 What's New in the LabKey 3.0.0 package
 ==============================
 
@@ -15,6 +9,7 @@ What's New in the LabKey 3.0.0 package
 - Query API - WAF encode "sql" parameter for execute_sql
     - WAF encoding of parameters is initially supported with LabKey Server v23.09
     - WAF encoding can be opted out of on execute_sql calls by specifying waf_encode_sql=False
+- Query API - add optional parameters to insert_rows, update_rows, and delete_rows
 
 What's New in the LabKey 2.6.1 package
 ==============================

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -6,7 +6,7 @@ What's New in the LabKey 2.7.0 package
 ==============================
 
 *Release date: TBD*
-- Query API - add optional parameters to insert_rows, select_rows, and delete_rows
+- Query API - add optional parameters to insert_rows, select_rows, update_rows, and delete_rows
 
 What's New in the LabKey 2.6.0 package
 ==============================

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -6,7 +6,7 @@ What's New in the LabKey 2.7.0 package
 ==============================
 
 *Release date: TBD*
-- Query API - add options parameter to insert_rows, select_rows, and delete_rows
+- Query API - add optional parameters to insert_rows, select_rows, and delete_rows
 
 What's New in the LabKey 2.6.0 package
 ==============================

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -204,10 +204,16 @@ def delete_rows(
         "schemaName": schema_name,
         "queryName": query_name,
         "rows": rows,
-        "transacted": transacted,
-        "auditBehavior": audit_behavior,
-        "auditUserComment": audit_user_comment
     }
+
+    if transacted is False:
+        payload["transacted"] = transacted
+
+    if audit_behavior is not None:
+        payload["auditBehavior"] = audit_behavior
+
+    if audit_user_comment is not None:
+        payload["auditUserComment"] = audit_user_comment
 
     return server_context.make_request(
         url,
@@ -342,6 +348,18 @@ def insert_rows(
         "auditBehavior": audit_behavior,
         "auditUserComment": audit_user_comment
     }
+
+    if skip_reselect_rows is True:
+        payload["skipReselectRows"] = skip_reselect_rows
+
+    if transacted is False:
+        payload["transacted"] = transacted
+
+    if audit_behavior is not None:
+        payload["auditBehavior"] = audit_behavior
+
+    if audit_user_comment is not None:
+        payload["auditUserComment"] = audit_user_comment
 
     return server_context.make_request(
         url,
@@ -486,10 +504,16 @@ def update_rows(
         "schemaName": schema_name,
         "queryName": query_name,
         "rows": rows,
-        "transacted": transacted,
-        "auditBehavior": audit_behavior,
-        "auditUserComment": audit_user_comment
     }
+
+    if transacted is False:
+        payload["transacted"] = transacted
+
+    if audit_behavior is not None:
+        payload["auditBehavior"] = audit_behavior
+
+    if audit_user_comment is not None:
+        payload["auditUserComment"] = audit_user_comment
 
     return server_context.make_request(
         url,

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -309,7 +309,7 @@ def insert_rows(
     payload = {"schemaName": schema_name, "queryName": query_name, "rows": rows}
 
     if options is not None:
-        payload = payload | options
+        payload = {**payload, **options}
 
     return server_context.make_request(
         url,

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -170,6 +170,7 @@ def delete_rows(
     query_name: str,
     rows: any,
     container_path: str = None,
+    options: dict = None,
     timeout: int = _default_timeout,
 ):
     """
@@ -179,11 +180,15 @@ def delete_rows(
     :param query_name: table name to delete from
     :param rows: Set of rows to delete
     :param container_path: labkey container path if not already set in context
+    :param options: Additional parameters
     :param timeout: timeout of request in seconds (defaults to 30s)
     :return:
     """
     url = server_context.build_url("query", "deleteRows.api", container_path=container_path)
     payload = {"schemaName": schema_name, "queryName": query_name, "rows": rows}
+
+    if options is not None:
+        payload = payload | options
 
     return server_context.make_request(
         url,
@@ -285,6 +290,7 @@ def insert_rows(
     query_name: str,
     rows: List[any],
     container_path: str = None,
+    options: dict = None,
     timeout: int = _default_timeout,
 ):
     """
@@ -294,12 +300,16 @@ def insert_rows(
     :param query_name: table name to insert into
     :param rows: set of rows to insert
     :param container_path: labkey container path if not already set in context
+    :param options: Additional parameters
     :param timeout: timeout of request in seconds (defaults to 30s)
     :return:
     """
     url = server_context.build_url("query", "insertRows.api", container_path=container_path)
 
     payload = {"schemaName": schema_name, "queryName": query_name, "rows": rows}
+
+    if options is not None:
+        payload = payload | options
 
     return server_context.make_request(
         url,
@@ -419,6 +429,7 @@ def update_rows(
     query_name: str,
     rows: List[any],
     container_path: str = None,
+    options: dict = None,
     timeout: int = _default_timeout,
 ):
     """
@@ -429,12 +440,16 @@ def update_rows(
     :param query_name: table name to update
     :param rows: Set of rows to update
     :param container_path: labkey container path if not already set in context
+    :param options: Additional parameters
     :param timeout: timeout of request in seconds (defaults to 30s)
     :return:
     """
     url = server_context.build_url("query", "updateRows.api", container_path=container_path)
 
     payload = {"schemaName": schema_name, "queryName": query_name, "rows": rows}
+
+    if options is not None:
+        payload = payload | options
 
     return server_context.make_request(
         url,
@@ -458,10 +473,11 @@ class QueryWrapper:
         query_name: str,
         rows: any,
         container_path: str = None,
+        options: dict = None,
         timeout: int = _default_timeout,
     ):
         return delete_rows(
-            self.server_context, schema_name, query_name, rows, container_path, timeout
+            self.server_context, schema_name, query_name, rows, container_path, options, timeout
         )
 
     @functools.wraps(truncate_table)
@@ -507,10 +523,11 @@ class QueryWrapper:
         query_name: str,
         rows: List[any],
         container_path: str = None,
+        options: dict = None,
         timeout: int = _default_timeout,
     ):
         return insert_rows(
-            self.server_context, schema_name, query_name, rows, container_path, timeout
+            self.server_context, schema_name, query_name, rows, container_path, options, timeout
         )
 
     @functools.wraps(select_rows)
@@ -566,8 +583,9 @@ class QueryWrapper:
         query_name: str,
         rows: List[any],
         container_path: str = None,
+        options: dict = None,
         timeout: int = _default_timeout,
     ):
         return update_rows(
-            self.server_context, schema_name, query_name, rows, container_path, timeout
+            self.server_context, schema_name, query_name, rows, container_path, options, timeout
         )

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -164,13 +164,25 @@ class QueryFilter:
         return "<QueryFilter [{} {} {}]>".format(self.column_name, self.filter_type, self.value)
 
 
+class AuditBehavior:
+    """
+    Enum of different auditing levels
+    """
+
+    DETAILED = "DETAILED"
+    NONE = "NONE"
+    SUMMARY = "SUMMARY"
+
+
 def delete_rows(
     server_context: ServerContext,
     schema_name: str,
     query_name: str,
     rows: any,
     container_path: str = None,
-    options: dict = None,
+    transacted: bool = True,
+    audit_behavior: AuditBehavior = None,
+    audit_user_comment: str = None,
     timeout: int = _default_timeout,
 ):
     """
@@ -180,15 +192,21 @@ def delete_rows(
     :param query_name: table name to delete from
     :param rows: Set of rows to delete
     :param container_path: labkey container path if not already set in context
-    :param options: Additional parameters
+    :param transacted: whether all of the updates should be done in a single transaction
+    :param audit_behavior: used to override the audit behavior for the update. See class query.AuditBehavior
+    :param audit_user_comment: used to provide a comment that will be attached to certain detailed audit log records
     :param timeout: timeout of request in seconds (defaults to 30s)
     :return:
     """
     url = server_context.build_url("query", "deleteRows.api", container_path=container_path)
-    payload = {"schemaName": schema_name, "queryName": query_name, "rows": rows}
-
-    if options is not None:
-        payload = payload | options
+    payload = {
+        "schemaName": schema_name,
+        "queryName": query_name,
+        "rows": rows,
+        "transacted": transacted,
+        "auditBehavior": audit_behavior,
+        "auditUserComment": audit_user_comment
+    }
 
     return server_context.make_request(
         url,
@@ -290,7 +308,10 @@ def insert_rows(
     query_name: str,
     rows: List[any],
     container_path: str = None,
-    options: dict = None,
+    skip_reselect_rows: bool = False,
+    transacted: bool = True,
+    audit_behavior: AuditBehavior = None,
+    audit_user_comment: str = None,
     timeout: int = _default_timeout,
 ):
     """
@@ -300,16 +321,24 @@ def insert_rows(
     :param query_name: table name to insert into
     :param rows: set of rows to insert
     :param container_path: labkey container path if not already set in context
-    :param options: Additional parameters
+    :param skip_reselect_rows: whether the full detailed response for the insert can be skipped
+    :param transacted: whether all of the updates should be done in a single transaction
+    :param audit_behavior: used to override the audit behavior for the update. See class query.AuditBehavior
+    :param audit_user_comment: used to provide a comment that will be attached to certain detailed audit log records
     :param timeout: timeout of request in seconds (defaults to 30s)
     :return:
     """
     url = server_context.build_url("query", "insertRows.api", container_path=container_path)
 
-    payload = {"schemaName": schema_name, "queryName": query_name, "rows": rows}
-
-    if options is not None:
-        payload = {**payload, **options}
+    payload = {
+        "schemaName": schema_name,
+        "queryName": query_name,
+        "rows": rows,
+        "skipReselectRows": skip_reselect_rows,
+        "transacted": transacted,
+        "auditBehavior": audit_behavior,
+        "auditUserComment": audit_user_comment
+    }
 
     return server_context.make_request(
         url,
@@ -429,7 +458,9 @@ def update_rows(
     query_name: str,
     rows: List[any],
     container_path: str = None,
-    options: dict = None,
+    transacted: bool = True,
+    audit_behavior: AuditBehavior = None,
+    audit_user_comment: str = None,
     timeout: int = _default_timeout,
 ):
     """
@@ -440,16 +471,22 @@ def update_rows(
     :param query_name: table name to update
     :param rows: Set of rows to update
     :param container_path: labkey container path if not already set in context
-    :param options: Additional parameters
+    :param transacted: whether all of the updates should be done in a single transaction
+    :param audit_behavior: used to override the audit behavior for the update. See class query.AuditBehavior
+    :param audit_user_comment: used to provide a comment that will be attached to certain detailed audit log records
     :param timeout: timeout of request in seconds (defaults to 30s)
     :return:
     """
     url = server_context.build_url("query", "updateRows.api", container_path=container_path)
 
-    payload = {"schemaName": schema_name, "queryName": query_name, "rows": rows}
-
-    if options is not None:
-        payload = payload | options
+    payload = {
+        "schemaName": schema_name,
+        "queryName": query_name,
+        "rows": rows,
+        "transacted": transacted,
+        "auditBehavior": audit_behavior,
+        "auditUserComment": audit_user_comment
+    }
 
     return server_context.make_request(
         url,
@@ -473,11 +510,21 @@ class QueryWrapper:
         query_name: str,
         rows: any,
         container_path: str = None,
-        options: dict = None,
+        transacted: bool = True,
+        audit_behavior: AuditBehavior = None,
+        audit_user_comment: str = None,
         timeout: int = _default_timeout,
     ):
         return delete_rows(
-            self.server_context, schema_name, query_name, rows, container_path, options, timeout
+            self.server_context,
+            schema_name,
+            query_name,
+            rows,
+            container_path,
+            transacted,
+            audit_behavior,
+            audit_user_comment,
+            timeout
         )
 
     @functools.wraps(truncate_table)
@@ -523,11 +570,23 @@ class QueryWrapper:
         query_name: str,
         rows: List[any],
         container_path: str = None,
-        options: dict = None,
+        skip_reselect_rows: bool = False,
+        transacted: bool = True,
+        audit_behavior: AuditBehavior = None,
+        audit_user_comment: str = None,
         timeout: int = _default_timeout,
     ):
         return insert_rows(
-            self.server_context, schema_name, query_name, rows, container_path, options, timeout
+            self.server_context,
+            schema_name,
+            query_name,
+            rows,
+            container_path,
+            skip_reselect_rows,
+            transacted,
+            audit_behavior,
+            audit_user_comment,
+            timeout
         )
 
     @functools.wraps(select_rows)
@@ -583,9 +642,19 @@ class QueryWrapper:
         query_name: str,
         rows: List[any],
         container_path: str = None,
-        options: dict = None,
+        transacted: bool = True,
+        audit_behavior: AuditBehavior = None,
+        audit_user_comment: str = None,
         timeout: int = _default_timeout,
     ):
         return update_rows(
-            self.server_context, schema_name, query_name, rows, container_path, options, timeout
+            self.server_context,
+            schema_name,
+            query_name,
+            rows,
+            container_path,
+            transacted,
+            audit_behavior,
+            audit_user_comment,
+            timeout
         )

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -200,11 +200,8 @@ def delete_rows(
     :return:
     """
     url = server_context.build_url("query", "deleteRows.api", container_path=container_path)
-    payload = {
-        "schemaName": schema_name,
-        "queryName": query_name,
-        "rows": rows,
-    }
+
+    payload = {"schemaName": schema_name, "queryName": query_name, "rows": rows}
 
     if transacted is False:
         payload["transacted"] = transacted
@@ -339,15 +336,7 @@ def insert_rows(
     """
     url = server_context.build_url("query", "insertRows.api", container_path=container_path)
 
-    payload = {
-        "schemaName": schema_name,
-        "queryName": query_name,
-        "rows": rows,
-        "skipReselectRows": skip_reselect_rows,
-        "transacted": transacted,
-        "auditBehavior": audit_behavior,
-        "auditUserComment": audit_user_comment
-    }
+    payload = {"schemaName": schema_name, "queryName": query_name, "rows": rows}
 
     if skip_reselect_rows is True:
         payload["skipReselectRows"] = skip_reselect_rows
@@ -500,11 +489,7 @@ def update_rows(
     """
     url = server_context.build_url("query", "updateRows.api", container_path=container_path)
 
-    payload = {
-        "schemaName": schema_name,
-        "queryName": query_name,
-        "rows": rows,
-    }
+    payload = {"schemaName": schema_name, "queryName": query_name, "rows": rows}
 
     if transacted is False:
         payload["transacted"] = transacted


### PR DESCRIPTION
#### Rationale
See more details [here](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48490). It is desired we add support for a couple of options passed to insert_rows, update_rows, and delete_rows. There are a notable amount of parameters that are supported on the server but not passed to these functions (around 8).  As such, it seemed more maintable and elegant to add an 'options' paramater to these functions rather than passing all ~8 explicitly.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-r/pull/98

#### Changes
* Update insert_rows, update_rows, and delete_rows
* Update change log
