### PR TITLE
Add move_rows() to query.py

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,13 +2,6 @@
 LabKey Python Client API News
 +++++++++++
 
-What's New in the LabKey 3.1.0 package
-==============================
-
-*Release date: TBD*
-- Query API - move_rows()
-    - earliest compatible LabKey Server version: 24.1.0
-
 What's New in the LabKey 3.0.0 package
 ==============================
 
@@ -17,6 +10,8 @@ What's New in the LabKey 3.0.0 package
     - WAF encoding of parameters is initially supported with LabKey Server v23.09
     - WAF encoding can be opted out of on execute_sql calls by specifying waf_encode_sql=False
 - Query API - add optional parameters to insert_rows, update_rows, and delete_rows
+- Query API - add move_rows()
+    - earliest compatible LabKey Server version: 24.1.0
 
 What's New in the LabKey 2.6.1 package
 ==============================

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,13 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 3.1.0 package
+==============================
+
+*Release date: TBD*
+- Query API - move_rows()
+    - earliest compatible LabKey Server version: 24.1.0
+
 What's New in the LabKey 3.0.0 package
 ==============================
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Query API - [sample code](samples/query_examples.py)
 - **insert_rows()** - Insert rows into a table.
 - **select_rows()** - Query and get results sets.
 - **update_rows()** - Update rows in a table.
+- **move_rows()()** - Move rows in a table.
 - **truncate_table()** - Delete all rows from a table.
 
 Domain API - [sample code](samples/domain_example.py)


### PR DESCRIPTION
#### Rationale
Related PR added a query-moveRows.api to the QueryController so that we could consolidate the various move entities actions to a single action. This PR adds move_rows() to the package.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/167
- https://github.com/LabKey/labkey-api-r/pull/100

#### Changes
- add move_rows() to query.py
