### PR TITLE
Add allow_redirects flag to ServerContext

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,15 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 3.1.0 package
+==============================
+
+*Release date: 04/??/2024*
+- ServerContext: Add allow_redirects flag (defaults to False)
+- APIWrapper: Add allow_redirects flag (defaults to False)
+- Add UnexpectedRedirectError
+    - thrown when allow_redirects is False and the server issues a redirect
+
 What's New in the LabKey 3.0.0 package
 ==============================
 

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -6,7 +6,9 @@ What's New in the LabKey 3.1.0 package
 ==============================
 
 *Release date: 04/??/2024*
-- ServerContext: Add allow_redirects flag (defaults to False)
+- ServerContext
+    - Add allow_redirects flag (defaults to False) to constructor
+    - Add allow_redirects flag to make_request
 - APIWrapper: Add allow_redirects flag (defaults to False)
 - Add UnexpectedRedirectError
     - thrown when allow_redirects is False and the server issues a redirect

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -5,7 +5,7 @@ LabKey Python Client API News
 What's New in the LabKey 3.1.0 package
 ==============================
 
-*Release date: 04/??/2024*
+*Release date: 04/03/2024*
 - ServerContext
     - Add allow_redirects flag (defaults to False) to constructor
     - Add allow_redirects flag to make_request

--- a/docs/api_wrapper.md
+++ b/docs/api_wrapper.md
@@ -51,13 +51,16 @@ See below for an example of how to properly use the APIWrapper class to create a
 from labkey.api_wrapper import APIWrapper
 
 print("Create an APIWrapper")
-labkey_server = 'localhost:8080'
-project_name = 'ModuleAssayTest'  # Project folder name
+labkey_server = 'www.example.com'
+container_path = 'ModuleAssayTest'  # Project folder name
 contextPath = 'labkey'
 schema = 'core'
 table = 'Users'
-api = APIWrapper(labkey_server, project_name, contextPath, use_ssl=False)
 
+# Note: If developing against localhost with https disabled, set use_ssl=False below
+api = APIWrapper(labkey_server, container_path, contextPath)
+
+# Makes an API request to https://www.example.com/labkey/ModuleAssayTest/query-getQuery.api
 result = api.query.select_rows(schema, table)
 
 if result is not None:

--- a/docs/api_wrapper.md
+++ b/docs/api_wrapper.md
@@ -23,20 +23,23 @@ It includes the following arguments:
 - Example: 'Project/Folder/Subfolder'
 
 **context_path** 
-- The default value is None. Depending on how the LabKey Server instance is implemented, it may be necessary to include a value for the context_path argument. If your LabKey Server instance has text after the base URL, that is the context path. 
+- Defaults to `None`. Depending on how the LabKey Server instance is implemented, it may be necessary to include a value for the context_path argument. If your LabKey Server instance has text after the base URL, that is the context path. 
 - Example: If your home project has a URL such as https://labkey.org/contextpath/home/project-begin.view, then the context path is 'contextpath'.
 
 **use_ssl**
-- The default value is True. This should be set to True if your server is configured to use SSL. If you are not sure if your server uses SSL, refer to any URL for accessing your server. Servers using SSL will have a URL that begins with `https://` instead of `http://`. LabKey Sample Manager-only clients must have this argument set to True.
+- Defaults to `True`. This should be set to True if your server is configured to use SSL. If you are not sure if your server uses SSL, refer to any URL for accessing your server. Servers using SSL will have a URL that begins with `https://` instead of `http://`. LabKey Sample Manager-only clients must have this argument set to True.
 
 **verify_ssl**
-- The default value is True. This argument toggles whether or not the SSL certificate is validated when attempting to connect to a server. This flag is useful when you are connecting to a development server with a self-signed SSL certificate, which would otherwise cause a failure. You should never disable this flag if you are connecting to a production server with a proper SSL certificate.
+- Defaults to `True`. This argument toggles whether or not the SSL certificate is validated when attempting to connect to a server. This flag is useful when you are connecting to a development server with a self-signed SSL certificate, which would otherwise cause a failure. You should never disable this flag if you are connecting to a production server with a proper SSL certificate.
 
 **api_key**
-- The default value is None. Scripts can authenticate their LabKey API calls by using either a netrc file (details on that here, https://www.labkey.org/Documentation/wiki-page.view?name=netrc) or an API key (details about API keys and how to generate and manage them are here, https://www.labkey.org/Documentation/wiki-page.view?name=apikey). 
+- Defaults to `None`. Scripts can authenticate their LabKey API calls by using either a netrc file (details on that here, https://www.labkey.org/Documentation/wiki-page.view?name=netrc) or an API key (details about API keys and how to generate and manage them are here, https://www.labkey.org/Documentation/wiki-page.view?name=apikey). 
 
 **disable_csrf** 
-- The default value is False. In most cases, this argument must be set to False for API calls to work successfully as CSRF tokens are a fundamental security mechanism. For more info about using CSRF with your LabKey Server instance, see here, https://www.labkey.org/Documentation/wiki-page.view?name=csrfProtection.
+- Defaults to `False`. In most cases, this argument must be set to False for API calls to work successfully as CSRF tokens are a fundamental security mechanism. For more info about using CSRF with your LabKey Server instance, see here, https://www.labkey.org/Documentation/wiki-page.view?name=csrfProtection.
+
+**allow_redirects**
+- Defaults to `False`. When the server issues a redirect during an API call the ServerContext will throw an error.
 
 ### Using LabKey Python APIs 
 

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 __title__ = "labkey"
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/api_wrapper.py
+++ b/labkey/api_wrapper.py
@@ -22,6 +22,7 @@ class APIWrapper:
         verify_ssl=True,
         api_key=None,
         disable_csrf=False,
+        allow_redirects=False,
     ):
         self.server_context = ServerContext(
             domain=domain,
@@ -31,6 +32,7 @@ class APIWrapper:
             verify_ssl=verify_ssl,
             api_key=api_key,
             disable_csrf=disable_csrf,
+            allow_redirects=allow_redirects,
         )
         self.container = ContainerWrapper(self.server_context)
         self.domain = DomainWrapper(self.server_context)

--- a/labkey/exceptions.py
+++ b/labkey/exceptions.py
@@ -61,6 +61,8 @@ class UnexpectedRedirectError(RequestError):
         # If the server is redirecting from http to https the user probably has a misconfigured ServerContext with use_ssl=False
         if server_response.url.startswith("http://") and location.startswith("https://"):
             self.message = "Redirected from http to https, set use_ssl=True in your APIWrapper or ServerContext"
+        elif location != "":
+            self.message = f"Unexpected redirect to: {location}"
 
 
 class QueryNotFoundError(RequestError):

--- a/labkey/exceptions.py
+++ b/labkey/exceptions.py
@@ -47,7 +47,20 @@ class RequestError(exceptions.RequestException):
             self.message = "No response received"
 
     def __str__(self):
-        return repr(self.message)
+        return str(self.message)
+
+
+class UnexpectedRedirectError(RequestError):
+    default_msg = "Unexpected redirect occurred"
+
+    def __init__(self, server_response, **kwargs):
+        super().__init__(server_response, **kwargs)
+
+        location = server_response.headers.get("Location", "")
+
+        # If the server is redirecting from http to https the user probably has a misconfigured ServerContext with use_ssl=False
+        if server_response.url.startswith("http://") and location.startswith("https://"):
+            self.message = "Redirected from http to https, set use_ssl=True in your APIWrapper or ServerContext"
 
 
 class QueryNotFoundError(RequestError):

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -258,7 +258,7 @@ def execute_sql(
     parameters: dict = None,
     required_version: float = None,
     timeout: int = _default_timeout,
-    waf_encode_sql: bool = True
+    waf_encode_sql: bool = True,
 ):
     """
     Execute sql query against a LabKey server.
@@ -535,7 +535,12 @@ def move_rows(
     """
     url = server_context.build_url("query", "moveRows.api", container_path=container_path)
 
-    payload = {"targetContainerPath": target_container_path, "schemaName": schema_name, "queryName": query_name, "rows": rows}
+    payload = {
+        "targetContainerPath": target_container_path,
+        "schemaName": schema_name,
+        "queryName": query_name,
+        "rows": rows,
+    }
 
     if transacted is False:
         payload["transacted"] = transacted
@@ -582,7 +587,7 @@ class QueryWrapper:
             transacted,
             audit_behavior,
             audit_user_comment,
-            timeout
+            timeout,
         )
 
     @functools.wraps(truncate_table)
@@ -605,7 +610,7 @@ class QueryWrapper:
         parameters: dict = None,
         required_version: float = None,
         timeout: int = _default_timeout,
-        waf_encode_sql: bool = True
+        waf_encode_sql: bool = True,
     ):
         return execute_sql(
             self.server_context,
@@ -620,7 +625,7 @@ class QueryWrapper:
             parameters,
             required_version,
             timeout,
-            waf_encode_sql
+            waf_encode_sql,
         )
 
     @functools.wraps(insert_rows)
@@ -646,7 +651,7 @@ class QueryWrapper:
             transacted,
             audit_behavior,
             audit_user_comment,
-            timeout
+            timeout,
         )
 
     @functools.wraps(select_rows)
@@ -716,7 +721,7 @@ class QueryWrapper:
             transacted,
             audit_behavior,
             audit_user_comment,
-            timeout
+            timeout,
         )
 
     @functools.wraps(move_rows)
@@ -742,5 +747,5 @@ class QueryWrapper:
             transacted,
             audit_behavior,
             audit_user_comment,
-            timeout
+            timeout,
         )

--- a/labkey/security.py
+++ b/labkey/security.py
@@ -279,7 +279,7 @@ def stop_impersonating(server_context: ServerContext):
     Stop impersonating a user while keeping the original user logged in.
     """
     url = server_context.build_url(LOGIN_CONTROLLER, "stopImpersonating.api")
-    return server_context.make_request(url)
+    return server_context.make_request(url, allow_redirects=True)
 
 
 @dataclass

--- a/labkey/server_context.py
+++ b/labkey/server_context.py
@@ -178,7 +178,9 @@ class ServerContext:
         non_json_response: bool = False,
         file_payload: any = None,
         json: dict = None,
+        allow_redirects=False,
     ) -> any:
+        allow_redirects_ = allow_redirects or self.allow_redirects
         if self._api_key is not None:
             if self._session.headers.get(API_KEY_TOKEN) is not self._api_key:
                 self._session.headers.update({API_KEY_TOKEN: self._api_key})
@@ -198,7 +200,7 @@ class ServerContext:
                     params=payload,
                     headers=headers,
                     timeout=timeout,
-                    allow_redirects=self.allow_redirects,
+                    allow_redirects=allow_redirects_,
                 )
             else:
                 if file_payload is not None:
@@ -208,7 +210,7 @@ class ServerContext:
                         files=file_payload,
                         headers=headers,
                         timeout=timeout,
-                        allow_redirects=self.allow_redirects,
+                        allow_redirects=allow_redirects_,
                     )
                 elif json is not None:
                     if headers is None:
@@ -222,7 +224,7 @@ class ServerContext:
                         data=data,
                         headers=headers_,
                         timeout=timeout,
-                        allow_redirects=self.allow_redirects,
+                        allow_redirects=allow_redirects_,
                     )
                 else:
                     response = self._session.post(
@@ -230,7 +232,7 @@ class ServerContext:
                         data=payload,
                         headers=headers,
                         timeout=timeout,
-                        allow_redirects=self.allow_redirects,
+                        allow_redirects=allow_redirects_,
                     )
             return handle_response(response, non_json_response)
         except RequestException as e:

--- a/labkey/server_context.py
+++ b/labkey/server_context.py
@@ -8,6 +8,7 @@ from labkey.exceptions import (
     QueryNotFoundError,
     ServerContextError,
     ServerNotFoundError,
+    UnexpectedRedirectError,
 )
 
 API_KEY_TOKEN = "apikey"
@@ -29,7 +30,8 @@ def handle_response(response, non_json_response=False):
                 content=response.content,
             )
             return result
-
+    elif sc == 302:
+        raise UnexpectedRedirectError(response)
     elif sc == 401:
         raise RequestAuthorizationError(response)
     elif sc == 404:
@@ -62,6 +64,7 @@ class ServerContext:
         verify_ssl=True,
         api_key=None,
         disable_csrf=False,
+        allow_redirects=False,
     ):
         self._container_path = container_path
         self._context_path = context_path
@@ -70,6 +73,7 @@ class ServerContext:
         self._verify_ssl = verify_ssl
         self._api_key = api_key
         self._disable_csrf = disable_csrf
+        self.allow_redirects = allow_redirects
         self._session = requests.Session()
         self._session.headers.update({"User-Agent": f"LabKey Python API/{__version__}"})
 
@@ -189,7 +193,13 @@ class ServerContext:
 
         try:
             if method == "GET":
-                response = self._session.get(url, params=payload, headers=headers, timeout=timeout)
+                response = self._session.get(
+                    url,
+                    params=payload,
+                    headers=headers,
+                    timeout=timeout,
+                    allow_redirects=self.allow_redirects,
+                )
             else:
                 if file_payload is not None:
                     response = self._session.post(
@@ -198,6 +208,7 @@ class ServerContext:
                         files=file_payload,
                         headers=headers,
                         timeout=timeout,
+                        allow_redirects=self.allow_redirects,
                     )
                 elif json is not None:
                     if headers is None:
@@ -206,10 +217,20 @@ class ServerContext:
                     headers_ = {**headers, "Content-Type": "application/json"}
                     # sort_keys is a hack to make unit tests work
                     data = json_dumps(json, sort_keys=True)
-                    response = self._session.post(url, data=data, headers=headers_, timeout=timeout)
+                    response = self._session.post(
+                        url,
+                        data=data,
+                        headers=headers_,
+                        timeout=timeout,
+                        allow_redirects=self.allow_redirects,
+                    )
                 else:
                     response = self._session.post(
-                        url, data=payload, headers=headers, timeout=timeout
+                        url,
+                        data=payload,
+                        headers=headers,
+                        timeout=timeout,
+                        allow_redirects=self.allow_redirects,
                     )
             return handle_response(response, non_json_response)
         except RequestException as e:

--- a/samples/experiment_platemetadata_example.py
+++ b/samples/experiment_platemetadata_example.py
@@ -42,9 +42,9 @@ run_test.data_rows = [
 
 # Assays that are configured for plate support have a required run property for the plate template, this is the plate
 # template lsid
-run_test.properties[
-    "PlateTemplate"
-] = "urn:lsid:labkey.com:PlateTemplate.Folder-6:d8bbec7d-34cd-1038-bd67-b3bd777822f8"
+run_test.properties["PlateTemplate"] = (
+    "urn:lsid:labkey.com:PlateTemplate.Folder-6:d8bbec7d-34cd-1038-bd67-b3bd777822f8"
+)
 
 # The assay plate metadata is a specially formatted JSON object to map properties to the well groups
 run_test.plate_metadata = {

--- a/test/integration/test_query.py
+++ b/test/integration/test_query.py
@@ -43,10 +43,14 @@ def study(api: APIWrapper):
         "subjectNounSingular": "People",
         "label": "Python Integration Tests Study",
     }
-    created_study = api.server_context.make_request(url, payload, non_json_response=True)
+    created_study = api.server_context.make_request(
+        url, payload, non_json_response=True, allow_redirects=True
+    )
     yield created_study
     url = api.server_context.build_url("study", "deleteStudy.view")
-    api.server_context.make_request(url, {"confirm": "true"}, non_json_response=True)
+    api.server_context.make_request(
+        url, {"confirm": "true"}, non_json_response=True, allow_redirects=True
+    )
 
 
 @pytest.fixture(scope="session")
@@ -91,7 +95,7 @@ def test_create_duplicate_dataset(api: APIWrapper, dataset):
     with pytest.raises(ServerContextError) as e:
         api.domain.create(DATASET_DOMAIN)
 
-    expected = f"'500: A Dataset or Query already exists with the name \"{QUERY_NAME}\".'"
+    expected = f'500: A Dataset or Query already exists with the name "{QUERY_NAME}".'
     assert e.value.message == expected
 
 
@@ -148,7 +152,7 @@ def test_cannot_delete_qc_state_in_use(api: APIWrapper, qc_states, study, datase
 
     assert (
         e.value.message
-        == "\"400: State 'needs verification' cannot be deleted as it is currently in use.\""
+        == "400: State 'needs verification' cannot be deleted as it is currently in use."
     )
     # now clean up/stop using it
     dataset_row_to_remove = [{"lsid": inserted_lsid}]

--- a/test/unit/test_domain.py
+++ b/test/unit/test_domain.py
@@ -70,6 +70,7 @@ class TestCreate(unittest.TestCase):
             "data": json.dumps(domain_definition, sort_keys=True),
             "headers": {"Content-Type": "application/json"},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), domain_definition]
@@ -116,6 +117,7 @@ class TestDrop(unittest.TestCase):
             "data": json.dumps(payload, sort_keys=True),
             "headers": {"Content-Type": "application/json"},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [
@@ -164,6 +166,7 @@ class TestGet(unittest.TestCase):
             "headers": None,
             "params": {"schemaName": self.schema_name, "queryName": self.query_name},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [
@@ -215,6 +218,7 @@ class TestInferFields(unittest.TestCase):
             "files": {"inferfile": self.file},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), self.file]
@@ -275,6 +279,7 @@ class TestSave(unittest.TestCase):
             "data": json.dumps(payload, sort_keys=True),
             "headers": {"Content-Type": "application/json"},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [
@@ -347,6 +352,7 @@ class TestConditionalFormatCreate(unittest.TestCase):
             "data": json.dumps(self.domain_definition, sort_keys=True),
             "headers": {"Content-Type": "application/json"},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), self.domain_definition]
@@ -431,6 +437,7 @@ class TestConditionalFormatSave(unittest.TestCase):
             "data": json.dumps(payload, sort_keys=True),
             "headers": {"Content-Type": "application/json"},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [

--- a/test/unit/test_experiment_api.py
+++ b/test/unit/test_experiment_api.py
@@ -208,6 +208,7 @@ class TestLoadBatch(unittest.TestCase):
             "data": '{"assayId": 12345, "batchId": 54321}',
             "headers": {"Content-Type": "application/json"},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), assay_id, batch_id]
@@ -290,6 +291,7 @@ class TestSaveBatch(unittest.TestCase):
             "data": '{"assayId": 12345, "batches": [{"batchProtocolId": null, "comment": null, "created": null, "createdBy": null, "modified": null, "modifiedBy": null, "name": null, "properties": {"PropertyName": "Property Value"}, "runs": [{"name": "python upload", "properties": {"RunFieldName": "Run Field Value"}}]}]}',
             "headers": {"Content-Type": "application/json"},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), assay_id, batch]

--- a/test/unit/test_query_api.py
+++ b/test/unit/test_query_api.py
@@ -78,6 +78,7 @@ class TestDeleteRows(unittest.TestCase):
             + '"}',
             "headers": {"Content-Type": "application/json"},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), schema, query, rows]
@@ -155,6 +156,7 @@ class TestUpdateRows(unittest.TestCase):
             + '"}',
             "headers": {"Content-Type": "application/json"},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), schema, query, rows]
@@ -232,6 +234,7 @@ class TestInsertRows(unittest.TestCase):
             + '"}',
             "headers": {"Content-Type": "application/json"},
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), schema, query, rows]
@@ -301,6 +304,7 @@ class TestExecuteSQL(unittest.TestCase):
             "data": {"sql": waf_encode(sql), "schemaName": schema},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), schema, sql]
@@ -369,6 +373,7 @@ class TestSelectRows(unittest.TestCase):
             "data": {"schemaName": schema, "query.queryName": query, "query.maxRows": -1},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), schema, query]

--- a/test/unit/test_security.py
+++ b/test/unit/test_security.py
@@ -65,6 +65,7 @@ class TestCreateUser(unittest.TestCase):
             "data": {"email": TestCreateUser.__email, "sendEmail": False},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), self.__email]
@@ -138,6 +139,7 @@ class TestResetPassword(unittest.TestCase):
             "data": {"email": TestResetPassword.__email},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), self.__email]
@@ -211,6 +213,7 @@ class TestActivateUsers(unittest.TestCase):
             "data": {"userId": [123]},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), self.__user_id]
@@ -284,6 +287,7 @@ class TestDeactivateUsers(unittest.TestCase):
             "data": {"userId": [123]},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), self.__user_id]
@@ -357,6 +361,7 @@ class TestDeleteUsers(unittest.TestCase):
             "data": {"userId": [123]},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), self.__user_id]
@@ -431,6 +436,7 @@ class TestAddToGroup(unittest.TestCase):
             "data": {"groupId": 123, "principalIds": [321]},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), self.__user_id, self.__group_id]
@@ -505,6 +511,7 @@ class TestRemoveFromGroup(unittest.TestCase):
             "data": {"groupId": 123, "principalIds": [321]},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), self.__user_id, self.__group_id]
@@ -584,6 +591,7 @@ class TestRemoveFromRole(unittest.TestCase):
             },
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [
@@ -668,6 +676,7 @@ class TestAddToRole(unittest.TestCase):
             },
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [
@@ -744,6 +753,7 @@ class TestGetRoles(unittest.TestCase):
             "data": None,
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service)]
@@ -815,6 +825,7 @@ class TestListGroups(unittest.TestCase):
             "data": {"includeSiteGroups": True},
             "headers": None,
             "timeout": 300,
+            "allow_redirects": False,
         }
 
         self.args = [mock_server_context(self.service), True]

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -8,11 +8,13 @@ def test_btoa():
 
 
 def test_encode_uri_component():
-    assert(
+    assert (
         encode_uri_component("SELECT * FROM x.y WHERE y = 5 & 2 AND y IS NOT NULL;")
         == "SELECT%20*%20FROM%20x.y%20WHERE%20y%20%3D%205%20%26%202%20AND%20y%20IS%20NOT%20NULL%3B"
     )
-    assert encode_uri_component("><&/%' \"1äöüÅ") == "%3E%3C%26%2F%25'%20%221%C3%A4%C3%B6%C3%BC%C3%85"
+    assert (
+        encode_uri_component("><&/%' \"1äöüÅ") == "%3E%3C%26%2F%25'%20%221%C3%A4%C3%B6%C3%BC%C3%85"
+    )
 
 
 def test_waf_encode():
@@ -20,5 +22,11 @@ def test_waf_encode():
     assert waf_encode(None) is None
     assert waf_encode("") == ""
     assert waf_encode("hello") == prefix + "aGVsbG8="
-    assert waf_encode("DELETE TABLE some.table;") == prefix + "REVMRVRFJTIwVEFCTEUlMjBzb21lLnRhYmxlJTNC"
-    assert waf_encode("><&/%' \"1äöüÅ") == prefix + "JTNFJTNDJTI2JTJGJTI1JyUyMCUyMjElQzMlQTQlQzMlQjYlQzMlQkMlQzMlODU="
+    assert (
+        waf_encode("DELETE TABLE some.table;")
+        == prefix + "REVMRVRFJTIwVEFCTEUlMjBzb21lLnRhYmxlJTNC"
+    )
+    assert (
+        waf_encode("><&/%' \"1äöüÅ")
+        == prefix + "JTNFJTNDJTI2JTJGJTI1JyUyMCUyMjElQzMlQTQlQzMlQjYlQzMlQkMlQzMlODU="
+    )


### PR DESCRIPTION
#### Rationale
This PR adds a flag to ServerContext, `allow_redirects` which defaults to `False`. This helps us catch misconfiguration in API clients where `use_ssl=False` when it should be `True`. This fixes [Issue 49934](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49934).

#### Related Pull Requests
* n/a

#### Changes
* ServerContext:
    * Add `allow_redirects` flag to constructor
    * Add `allow_redirects` flag to `make_request`
* APIWrapper Add `allow_redirects` flag
* Add UnexpectedRedirectError
* Update APIWrapper docs to not set `use_ssl=False` in example code
