### PR TITLE
Add optional build dependencies, instructions for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: build
+build:
+	python -m build
+
+.PHONY: release-test
+release-test:
+	twine upload dist/* -r testpypi
+
+.PHONY: release
+release:
+	twine upload dist/* -r pypi
+
+.PHONY: install
+install:
+	pip install -e '.[dev,build]'
+
+.PHONY: uninstall
+uninstall:
+	pip uninstall -y labkey

--- a/README.md
+++ b/README.md
@@ -117,29 +117,28 @@ Python 3.7+ is fully supported.
 LabKey Server v15.1 and later.
 
 ## Contributing
-This package is maintained by [LabKey](http://www.labkey.com/). If you have any questions or need support, please use
-the [LabKey Server developer support forum](https://www.labkey.org/home/developer/forum/project-start.view).
+This package is maintained by [LabKey](http://www.labkey.com/). If you have any questions or need support, please use the
+[LabKey Server developer support forum](https://www.labkey.org/home/developer/forum/project-start.view).
 
+### Setup
 To install the necessary dependencies for local development you can run the following command:
 
 ```bash
-pip install -e .
+pip install -e '.[test]'
 ```
 
-When contributing changes please use `Black` to format your code. To run Black follow these instructions:
-1. Install black: `pip install black`
-2. Run black: `black .`
-3. Commit the newly formatted code.
+
+### Formatting your code
+When contributing changes please use `Black` to format your code. To run Black you can run the following command:
+```bash
+black .
+```
+
+After black has run it may have formatted some files, commit the changed files before opening a PR.
 
 ### Testing
-If you are looking to contribute please run the tests before issuing a PR. To run the tests you'll need to install the
-additional testing dependencies, to do this run:
+If you are looking to contribute please run the tests before issuing a PR. The tests can be run with:
 
-```bash
-$ pip install -e '.[test]'
-```
-
-Then, the tests can be run with
 ```bash
 $ pytest .
 ```
@@ -154,3 +153,20 @@ $ pytest . -m "integration"
 ### Maintainers
 Package maintainer's can reference the [Python Package Maintenance](https://docs.google.com/document/d/13nVxwyctH4YZ6gDhcrOu9Iz6qGFPAxicE1VHiVYpw9A/) document (requires permission) for updating
 releases.
+
+To build the package before releasing you will need to install the build dependencies. This can be done by running:
+
+```bash
+pip install -e '.[build]'
+```
+
+To build the package you can run:
+
+```bash
+python -m build
+```
+
+You should now have a `dist/` folder with two files:
+
+1. `labkey-<version from __init__.py>.tar.gz` - This is the source distribution
+2. `labkey-<version from __init__.py>-py3-none-any.whl` - This is the wheel

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This package is maintained by [LabKey](http://www.labkey.com/). If you have any 
 To install the necessary dependencies for local development you can run the following command:
 
 ```bash
-pip install -e '.[test]'
+pip install -e '.[dev]'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ pip install -e '.[dev]'
 
 ### Formatting your code
 When contributing changes please use `Black` to format your code. To run Black you can run the following command:
+
 ```bash
 black .
 ```

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ if not version:
 long_desc = "Python client API for LabKey Server. Supports query and experiment APIs."
 
 tests_require = ["pytest", "requests", "mock", "pytest-cov"]
+dev_require = ["pytest", "requests", "mock", "pytest-cov", "black"]
+build_require = ["setuptools", "build", "twine", "wheel"]
 
 setup(
     name="labkey",
@@ -48,7 +50,7 @@ setup(
     packages=packages,
     package_data={},
     install_requires=["requests"],
-    extras_require={"test": tests_require},
+    extras_require={"test": tests_require, "dev": dev_require, "build": build_require},
     keywords="labkey api client",
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
#### Rationale
Running `setup.py sdist` and any other command from setup.py directly is deprecated. This PR updates setup.py to add some optional build dependencies that will assist us in buliding out package without calling setup.py directly. This PR also adds build instructions, and a Makefile for convenience.

#### Related Pull Requests
* n/a

#### Changes
* Add optional build dependencies
* Add optional dev dependencies
* Add instructions for building
* Add Makefile with convenience methods for installing, building, and releasing
