### PR TITLE
Add "valueExpression" to PropertyDescriptor class (needed for creating/adding domain calculated fields)

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,13 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey TBD package
+==============================
+
+*Release date: TBD*
+- Add "valueExpression" to PropertyDescriptor class
+    - needed for creating/adding domain calculated fields
+
 What's New in the LabKey 3.3.0 package
 ==============================
 

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,12 +2,13 @@
 LabKey Python Client API News
 +++++++++++
 
-What's New in the LabKey TBD package
+What's New in the LabKey 3.4.0 package
 ==============================
 
 *Release date: TBD*
 - Add "valueExpression" to PropertyDescriptor class
     - needed for creating/adding domain calculated fields
+    - update Domain class to append calculatedFields to the domain's fields
 
 What's New in the LabKey 3.3.0 package
 ==============================

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 __title__ = "labkey"
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/domain.py
+++ b/labkey/domain.py
@@ -234,9 +234,11 @@ class Domain:
             "template_description", kwargs.pop("templateDescription", None)
         )
 
-        fields = kwargs.pop("fields", [])
         fields_instances = []
-
+        fields = kwargs.pop("fields", [])
+        for field in fields:
+            fields_instances.append(PropertyDescriptor(**field))
+        fields = kwargs.pop("calculatedFields", [])
         for field in fields:
             fields_instances.append(PropertyDescriptor(**field))
 

--- a/labkey/domain.py
+++ b/labkey/domain.py
@@ -238,7 +238,7 @@ class Domain:
         fields = kwargs.pop("fields", [])
         for field in fields:
             fields_instances.append(PropertyDescriptor(**field))
-        fields = kwargs.pop("calculatedFields", [])
+        fields = kwargs.pop("calculated_fields", kwargs.pop("calculatedFields", []))
         for field in fields:
             fields_instances.append(PropertyDescriptor(**field))
 

--- a/labkey/domain.py
+++ b/labkey/domain.py
@@ -109,6 +109,7 @@ class PropertyDescriptor:
         )
         self.type_editable = kwargs.pop("type_editable", kwargs.pop("typeEditable", None))
         self.url = kwargs.pop("url", None)
+        self.value_expression = kwargs.pop("value_expression", kwargs.pop("valueExpression", None))
 
     def to_json(self, strip_none=True):
         # TODO: Likely only want to include those that are not None
@@ -155,6 +156,7 @@ class PropertyDescriptor:
             "shownInUpdateView": self.shown_in_update_view,
             "typeEditable": self.type_editable,
             "url": self.url,
+            "valueExpression": self.value_expression,
         }
 
         json_formats = []

--- a/test/integration/test_domain.py
+++ b/test/integration/test_domain.py
@@ -261,3 +261,21 @@ def test_domain_save_options(api: APIWrapper, list_fixture):
 
     updated_domain, updated_options = api.domain.get_domain_details(LISTS_SCHEMA, LIST_NAME)
     assert updated_options.get("description") == expected_description
+
+
+def test_domain_add_calculated_field(api: APIWrapper, list_fixture):
+    domain, options = api.domain.get_domain_details(LISTS_SCHEMA, LIST_NAME)
+    domain.add_field({"name": "calcDouble", "conceptURI": "http://www.labkey.org/exp/xml#calculated", "valueExpression": "rowId * 2"})
+    domain.add_field({"name": "calcCube", "conceptURI": "http://www.labkey.org/exp/xml#calculated", "valueExpression": "power(rowId, 3)"})
+
+    api.domain.save(LISTS_SCHEMA, LIST_NAME, domain, options=options)
+    saved_domain = api.domain.get(LISTS_SCHEMA, LIST_NAME)
+
+    assert len(saved_domain.fields) == 4
+    for field in saved_domain.fields:
+        if field.name == "calcDouble":
+            assert field.concept_uri == "http://www.labkey.org/exp/xml#calculated"
+            assert field.value_expression == "rowId * 2"
+        if field.name == "calcCube":
+            assert field.concept_uri == "http://www.labkey.org/exp/xml#calculated"
+            assert field.value_expression == "power(rowId, 3)"


### PR DESCRIPTION
#### Rationale
A client requested an example script for adding a calculated field to an existing LK domain (i.e. List or Sample Type). We already have examples and API support get getting domains, adding fields, and saving domain updates. However, the PropertyDescriptor class doesn't support the "valueExpression" property needed for the calculated field definition.

#### Changes
- add "valueExpression" to PropertyDescriptor class
- update Domain class to append calculatedFields to the domain's fields
- add integration test for adding calculated fields to a domain
