### PR TITLE
Add save_rows to Query API

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,14 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 4.0.0 package
+==============================
+
+*Release date: 07/08/2025*
+- Add save_rows API to query module
+    - Accessible via API wrappers e.g. api.query.save_rows
+- Update the minimum required version of Python to 3.10
+
 What's New in the LabKey 3.4.0 package
 ==============================
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ else:
 ```
 
 ## Supported Versions
-Python 3.7+ is fully supported.
+# Note: update setup.py python_requires if you change this
+Python 3.10+ is fully supported.
 LabKey Server v15.1 and later.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ else:
 ```
 
 ## Supported Versions
-# Note: update setup.py python_requires if you change this
-Python 3.10+ is fully supported.
+Python 3.10+ is fully supported. <!-- Note: update setup.py python_requires if you change this -->
 LabKey Server v15.1 and later.
 
 ## Contributing

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 __title__ = "labkey"
-__version__ = "3.4.0"
+__version__ = "4.0.0"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/labkey/query.py
+++ b/labkey/query.py
@@ -15,15 +15,15 @@
 #
 """
 ############################################################################
-NAME: 
-LabKey Query API 
+NAME:
+LabKey Query API
 
-SUMMARY:  
+SUMMARY:
 This module provides functions for interacting with data on a LabKey Server.
 
 DESCRIPTION:
-This module is designed to simplify querying and manipulating data in LabKey Server.  
-Its APIs are modeled after the LabKey Server JavaScript APIs of the same names. 
+This module is designed to simplify querying and manipulating data in LabKey Server.
+Its APIs are modeled after the LabKey Server JavaScript APIs of the same names.
 
 Installation and Setup for the LabKey Python API:
 https://github.com/LabKey/labkey-api-python/blob/master/README.md
@@ -41,7 +41,7 @@ https://www.labkey.org/home/developer/forum/project-start.view
 ############################################################################
 """
 import functools
-from typing import List, TextIO
+from typing import List, Literal, NotRequired, TextIO, TypedDict
 
 from .server_context import ServerContext
 from .utils import waf_encode
@@ -196,7 +196,7 @@ def delete_rows(
     :param transacted: whether all of the updates should be done in a single transaction
     :param audit_behavior: used to override the audit behavior for the update. See class query.AuditBehavior
     :param audit_user_comment: used to provide a comment that will be attached to certain detailed audit log records
-    :param timeout: timeout of request in seconds (defaults to 30s)
+    :param timeout: timeout of request in seconds (defaults to 300s)
     :return:
     """
     url = server_context.build_url("query", "deleteRows.api", container_path=container_path)
@@ -232,7 +232,7 @@ def truncate_table(
     :param schema_name: schema of table
     :param query_name: table name to delete from
     :param container_path: labkey container path if not already set in context
-    :param timeout: timeout of request in seconds (defaults to 30s)
+    :param timeout: timeout of request in seconds (defaults to 300s)
     :return:
     """
     url = server_context.build_url("query", "truncateTable.api", container_path=container_path)
@@ -275,7 +275,7 @@ def execute_sql(
     :param save_in_session: save query result as a named view to the session
     :param parameters: parameter values to pass through to a parameterized query
     :param required_version: Api version of response
-    :param timeout: timeout of request in seconds (defaults to 30s)
+    :param timeout: timeout of request in seconds (defaults to 300s)
     :param waf_encode_sql: WAF encode sql in request (defaults to True)
     :return:
     """
@@ -331,7 +331,7 @@ def insert_rows(
     :param transacted: whether all of the updates should be done in a single transaction
     :param audit_behavior: used to override the audit behavior for the update. See class query.AuditBehavior
     :param audit_user_comment: used to provide a comment that will be attached to certain detailed audit log records
-    :param timeout: timeout of request in seconds (defaults to 30s)
+    :param timeout: timeout of request in seconds (defaults to 300s)
     :return:
     """
     url = server_context.build_url("query", "insertRows.api", container_path=container_path)
@@ -407,6 +407,93 @@ def import_rows(
     return server_context.make_request(url, payload, method="POST", file_payload=file_payload)
 
 
+class Command(TypedDict):
+    """
+    TypedDict representing a command for saveRows API.
+    """
+
+    audit_behavior: NotRequired[AuditBehavior]
+    audit_user_comment: NotRequired[str]
+    command: Literal["insert", "update", "delete"]
+    container_path: NotRequired[str]
+    extra_context: NotRequired[dict]
+    query_name: str
+    rows: List[any]
+    schema_name: str
+    skip_reselect_rows: NotRequired[bool]
+
+
+def save_rows(
+    server_context: ServerContext,
+    commands: List[Command],
+    api_version: float = None,
+    container_path: str = None,
+    extra_context: dict = None,
+    timeout: int = _default_timeout,
+    transacted: bool = None,
+    validate_only: bool = None,
+):
+    """
+    Save inserts, updates, and/or deletes to potentially multiple tables with a single request.
+    :param server_context: A LabKey server context. See utils.create_server_context.
+    :param commands: A List of the update/insert/delete operations to be performed.
+    :param api_version: decimal value that indicates the response version of the api. If this is 13.2 or higher, a
+    request that fails validation will be returned as a successful response. Use the 'errorCount' and 'committed'
+    properties in the response to tell if it committed or not.
+    :param container_path: folder path if not already part of server_context
+    :param extra_context: Extra context object passed into the transformation/validation script environment.
+    :param timeout: Request timeout in seconds (defaults to 300s)
+    :param transacted: Whether all the commands should be done in a single transaction, so they all succeed or all
+    fail. Defaults to true.
+    :param validate_only: Whether the server should attempt to proceed through all the commands but not commit them to
+    the database. Useful for scenarios like giving incremental validation feedback as a user fills out a UI form but
+    does not save anything until they explicitly request a save.
+    """
+    url = server_context.build_url("query", "saveRows.api", container_path=container_path)
+
+    json_commands = []
+    for command in commands:
+        json_command = {
+            "command": command["command"],
+            "queryName": command["query_name"],
+            "schemaName": command["schema_name"],
+            "rows": command["rows"],
+        }
+
+        if command.get("audit_behavior") is not None:
+            json_command["auditBehavior"] = command["audit_behavior"]
+
+        if command.get("audit_user_comment") is not None:
+            json_command["auditUserComment"] = command["audit_user_comment"]
+
+        if command.get("container_path") is not None:
+            json_command["containerPath"] = command["container_path"]
+
+        if command.get("extra_context") is not None:
+            json_command["extraContext"] = command["extra_context"]
+
+        if command.get("skip_reselect_rows") is not None:
+            json_command["skipReselectRows"] = command["skip_reselect_rows"]
+
+        json_commands.append(json_command)
+
+    payload = {"commands": json_commands}
+
+    if api_version is not None:
+        payload["apiVersion"] = api_version
+
+    if extra_context is not None:
+        payload["extraContext"] = extra_context
+
+    if transacted is not None:
+        payload["transacted"] = transacted
+
+    if validate_only is not None:
+        payload["validateOnly"] = validate_only
+
+    return server_context.make_request(url, json=payload, timeout=timeout)
+
+
 def select_rows(
     server_context: ServerContext,
     schema_name: str,
@@ -450,7 +537,7 @@ def select_rows(
     :param include_update_column: Boolean value that indicates whether to include an Update link column in results
     :param selection_key:
     :param required_version: decimal value that indicates the response version of the api
-    :param timeout: Request timeout in seconds (defaults to 30s)
+    :param timeout: Request timeout in seconds (defaults to 300s)
     :param ignore_filter: Boolean, if true, the command will ignore any filter that may be part of the chosen view.
     :return:
     """
@@ -534,7 +621,7 @@ def update_rows(
     :param transacted: whether all of the updates should be done in a single transaction
     :param audit_behavior: used to override the audit behavior for the update. See class query.AuditBehavior
     :param audit_user_comment: used to provide a comment that will be attached to certain detailed audit log records
-    :param timeout: timeout of request in seconds (defaults to 30s)
+    :param timeout: timeout of request in seconds (defaults to 300s)
     :return:
     """
     url = server_context.build_url("query", "updateRows.api", container_path=container_path)
@@ -580,7 +667,7 @@ def move_rows(
     :param transacted: whether all of the updates should be done in a single transaction
     :param audit_behavior: used to override the audit behavior for the update. See class query.AuditBehavior
     :param audit_user_comment: used to provide a comment that will be attached to certain detailed audit log records
-    :param timeout: timeout of request in seconds (defaults to 30s)
+    :param timeout: timeout of request in seconds (defaults to 300s)
     :return:
     """
     url = server_context.build_url("query", "moveRows.api", container_path=container_path)
@@ -724,6 +811,28 @@ class QueryWrapper:
             insert_option,
             audit_behavior,
             import_lookup_by_alternate_key,
+        )
+
+    @functools.wraps(save_rows)
+    def save_rows(
+        self,
+        commands: List[Command],
+        api_version: float = None,
+        container_path: str = None,
+        extra_context: dict = None,
+        timeout: int = _default_timeout,
+        transacted: bool = None,
+        validate_only: bool = None,
+    ):
+        return save_rows(
+            self.server_context,
+            commands,
+            api_version,
+            container_path,
+            extra_context,
+            timeout,
+            transacted,
+            validate_only,
         )
 
     @functools.wraps(select_rows)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     url="https://github.com/LabKey/labkey-api-python",
     packages=packages,
     package_data={},
+    python_requires=">=3.10", # Note: update README.md supported versions if you change this
     install_requires=["requests"],
     extras_require={"test": tests_require, "dev": dev_require, "build": build_require},
     keywords="labkey api client",

--- a/test/integration/test_query.py
+++ b/test/integration/test_query.py
@@ -242,14 +242,14 @@ def test_import_rows(api: APIWrapper, parent_list_fixture, child_list_fixture, t
 
     # Should succeed
     parent_file = parent_data_path.open()
-    resp = api.query.import_rows("lists", PARENT_LIST_NAME, data_file=parent_file)
+    resp = api.query.import_rows(LISTS_SCHEMA, PARENT_LIST_NAME, data_file=parent_file)
     parent_file.close()
     assert resp["success"] == True
     assert resp["rowCount"] == 3
 
     # Should fail, because data doesn't use rowIds and import_lookup_by_alternate_key defaults to False
     child_file = child_data_path.open()
-    resp = api.query.import_rows("lists", CHILD_LIST_NAME, data_file=child_file)
+    resp = api.query.import_rows(LISTS_SCHEMA, CHILD_LIST_NAME, data_file=child_file)
     child_file.close()
     assert resp["success"] == False
     assert resp["errorCount"] == 1
@@ -261,8 +261,152 @@ def test_import_rows(api: APIWrapper, parent_list_fixture, child_list_fixture, t
     # Should pass, because import_lookup_by_alternate_key is True
     child_file = child_data_path.open()
     resp = api.query.import_rows(
-        "lists", CHILD_LIST_NAME, data_file=child_file, import_lookup_by_alternate_key=True
+        LISTS_SCHEMA, CHILD_LIST_NAME, data_file=child_file, import_lookup_by_alternate_key=True
     )
     child_file.close()
     assert resp["success"] == True
     assert resp["rowCount"] == 3
+
+
+SAMPLES_SCHEMA = "samples"
+BLOOD_SAMPLE_TYPE = "Blood"
+TISSUE_SAMPLE_TYPE = "Tissues"
+
+
+@pytest.fixture
+def blood_sample_type_fixture(api: APIWrapper):
+    api.domain.create(
+        {
+            "kind": "SampleSet",
+            "domainDesign": {
+                "name": BLOOD_SAMPLE_TYPE,
+                "description": "Blood samples.",
+                "fields": [
+                    {"name": "Name", "rangeURI": "string"},
+                    {"name": "volume_mL", "rangeURI": "int"},
+                    {"name": "DrawDate", "rangeURI": "dateTime"},
+                    {"name": "ReceivedDate", "rangeURI": "dateTime"},
+                    {"name": "ProblemWithTube", "rangeURI": "boolean"},
+                ],
+            },
+        }
+    )
+    created_sample_type = api.domain.get(SAMPLES_SCHEMA, BLOOD_SAMPLE_TYPE)
+    yield created_sample_type
+    # clean up
+    api.domain.drop(SAMPLES_SCHEMA, BLOOD_SAMPLE_TYPE)
+
+
+@pytest.fixture
+def tissue_sample_type_fixture(api: APIWrapper):
+    api.domain.create(
+        {
+            "kind": "SampleSet",
+            "domainDesign": {
+                "name": TISSUE_SAMPLE_TYPE,
+                "description": "Tissue samples.",
+                "fields": [
+                    {"name": "Name", "rangeURI": "string"},
+                    {"name": "mass_mg", "rangeURI": "int"},
+                    {"name": "ReceivedDate", "rangeURI": "dateTime"},
+                ],
+            },
+        }
+    )
+    created_sample_type = api.domain.get(SAMPLES_SCHEMA, TISSUE_SAMPLE_TYPE)
+    yield created_sample_type
+    # clean up
+    api.domain.drop(SAMPLES_SCHEMA, TISSUE_SAMPLE_TYPE)
+
+
+def test_api_save_rows(api: APIWrapper, blood_sample_type_fixture, tissue_sample_type_fixture):
+    commands = [
+        {
+            "command": "insert",
+            "schema_name": SAMPLES_SCHEMA,
+            "query_name": BLOOD_SAMPLE_TYPE,
+            "rows": [{"name": "BL-1"}, {"description": "Should be BL-2 but I forgot to name it"}],
+        },
+        {
+            "command": "insert",
+            "schema_name": SAMPLES_SCHEMA,
+            "query_name": TISSUE_SAMPLE_TYPE,
+            "rows": [{"name": "T-1"}],
+        },
+    ]
+
+    # Expect to fail this request since the sample name was not specified for one of the rows
+    with pytest.raises(ServerContextError) as e:
+        api.query.save_rows(commands=commands)
+    assert e.value.message == "400: SampleID or Name is required for sample on row 2"
+
+    # Attempt the same request but with a 13.2 api version
+    resp = api.query.save_rows(api_version=13.2, commands=commands)
+    assert resp["committed"] == False
+    assert resp["errorCount"] == 1
+    assert (
+        resp["result"][0]["errors"]["exception"]
+        == "SampleID or Name is required for sample on row 2"
+    )
+
+    # Fix the first command by specifying a name for the sample
+    commands[0]["rows"][1]["name"] = "BL-2"
+
+    resp = api.query.save_rows(commands=commands)
+    assert resp["committed"] == True
+    assert resp["errorCount"] == 0
+    assert len(resp["result"][0]["rows"]) == 2
+    assert len(resp["result"][1]["rows"]) == 1
+
+    first_blood_row_id = resp["result"][0]["rows"][0]["rowid"]
+    assert first_blood_row_id > 0
+
+    first_tissue_row_id = resp["result"][1]["rows"][0]["rowid"]
+    assert first_tissue_row_id > 0
+
+    # Perform an insert, update, and delete all in the same request
+    commands = [
+        {
+            "command": "insert",
+            "schema_name": SAMPLES_SCHEMA,
+            "query_name": BLOOD_SAMPLE_TYPE,
+            "rows": [
+                {"name": "BL-3", "MaterialInputs/Tissues": "T-1"},
+                {"name": "BL-4", "MaterialInputs/Blood": "BL-2"},
+            ],
+        },
+        {
+            "command": "delete",
+            "schema_name": SAMPLES_SCHEMA,
+            "query_name": BLOOD_SAMPLE_TYPE,
+            "rows": [
+                {"rowId": first_blood_row_id},
+            ],
+        },
+        {
+            "command": "update",
+            "schema_name": SAMPLES_SCHEMA,
+            "query_name": TISSUE_SAMPLE_TYPE,
+            "rows": [
+                {"rowId": first_tissue_row_id, "ReceivedDate": "2025-07-07 12:34:56"},
+            ],
+        },
+    ]
+
+    resp = api.query.save_rows(commands=commands)
+    assert resp["committed"] == True
+    assert resp["errorCount"] == 0
+
+    # Verify insert
+    assert resp["result"][0]["rowsAffected"] == 2
+    assert resp["result"][0]["rows"][0]["name"] == "BL-3"
+    assert resp["result"][0]["rows"][1]["name"] == "BL-4"
+
+    # Verify delete
+    assert resp["result"][1]["rowsAffected"] == 1
+    assert resp["result"][1]["rows"][0]["rowid"] == first_blood_row_id
+
+    # Verify update
+    assert resp["result"][2]["rowsAffected"] == 1
+    assert resp["result"][2]["rows"][0]["rowid"] == first_tissue_row_id
+    assert resp["result"][2]["rows"][0]["receiveddate"] == "2025-07-07 12:34:56.000"

--- a/test/unit/test_query_api.py
+++ b/test/unit/test_query_api.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import json
 import unittest
-
-import unittest.mock as mock
 
 from labkey.query import (
     delete_rows,
     update_rows,
     insert_rows,
+    save_rows,
     select_rows,
     execute_sql,
     QueryFilter,
@@ -55,6 +55,10 @@ class MockExecuteSQL(MockLabKey):
 
 class MockUpdateRows(MockLabKey):
     api = "updateRows.api"
+
+
+class MockSaveRows(MockLabKey):
+    api = "saveRows.api"
 
 
 schema = "testSchema"
@@ -460,6 +464,194 @@ class TestSelectRows(unittest.TestCase):
         )
 
 
+class TestSaveRows(unittest.TestCase):
+    def setUp(self):
+        self.service = MockSaveRows()
+        commands = [
+            {
+                "command": "insert",
+                "schema_name": "exp",
+                "query_name": "materials",
+                "rows": [{"name": "New Sample 1"}],
+            }
+        ]
+
+        expected_payload = {
+            "commands": [
+                {
+                    "command": "insert",
+                    "schemaName": "exp",
+                    "queryName": "materials",
+                    "rows": [{"name": "New Sample 1"}],
+                }
+            ]
+        }
+
+        self.expected_kwargs = {
+            "expected_args": [self.service.get_server_url()],
+            "data": json.dumps(expected_payload, sort_keys=True),
+            "headers": {"Content-Type": "application/json"},
+            "timeout": 300,
+            "allow_redirects": False,
+        }
+
+        self.args = [mock_server_context(self.service), commands]
+
+    def test_success(self):
+        test = self
+        success_test(
+            test,
+            self.service.get_successful_response(),
+            save_rows,
+            True,
+            *self.args,
+            **self.expected_kwargs
+        )
+
+    def test_unauthorized(self):
+        test = self
+        throws_error_test(
+            test,
+            RequestAuthorizationError,
+            self.service.get_unauthorized_response(),
+            save_rows,
+            *self.args,
+            **self.expected_kwargs
+        )
+
+    def test_query_not_found(self):
+        test = self
+        throws_error_test(
+            test,
+            QueryNotFoundError,
+            self.service.get_query_not_found_response(),
+            save_rows,
+            *self.args,
+            **self.expected_kwargs
+        )
+
+    def test_server_not_found(self):
+        test = self
+        throws_error_test(
+            test,
+            ServerNotFoundError,
+            self.service.get_server_not_found_response(),
+            save_rows,
+            *self.args,
+            **self.expected_kwargs
+        )
+
+    def test_general_error(self):
+        test = self
+        throws_error_test(
+            test,
+            RequestError,
+            self.service.get_general_error_response(),
+            save_rows,
+            *self.args,
+            **self.expected_kwargs
+        )
+
+    def test_with_optional_command_fields(self):
+        """Test save_rows with all optional fields populated in command"""
+        commands = [
+            {
+                "command": "update",
+                "schema_name": "exp",
+                "query_name": "materials",
+                "rows": [{"rowId": 1, "name": "Updated Sample"}],
+                "audit_behavior": "DETAILED",
+                "audit_user_comment": "Test update comment",
+                "container_path": "/custom/path",
+                "extra_context": {"custom": "data"},
+                "skip_reselect_rows": True,
+            }
+        ]
+
+        expected_payload = {
+            "commands": [
+                {
+                    "command": "update",
+                    "schemaName": "exp",
+                    "queryName": "materials",
+                    "rows": [{"rowId": 1, "name": "Updated Sample"}],
+                    "auditBehavior": "DETAILED",
+                    "auditUserComment": "Test update comment",
+                    "containerPath": "/custom/path",
+                    "extraContext": {"custom": "data"},
+                    "skipReselectRows": True,
+                }
+            ]
+        }
+
+        expected_kwargs = {
+            "expected_args": [self.service.get_server_url()],
+            "data": json.dumps(expected_payload, sort_keys=True),
+            "headers": {"Content-Type": "application/json"},
+            "timeout": 300,
+            "allow_redirects": False,
+        }
+
+        args = [mock_server_context(self.service), commands]
+
+        success_test(
+            self, self.service.get_successful_response(), save_rows, True, *args, **expected_kwargs
+        )
+
+    def test_with_optional_parameters(self):
+        api_version = 18.21
+        commands = [
+            {
+                "command": "delete",
+                "schema_name": "exp",
+                "query_name": "materials",
+                "rows": [{"rowId": 1}],
+            }
+        ]
+        extra_context = {"global": "context"}
+        transacted = False
+        timeout = 600
+        validate_only = True
+
+        expected_payload = {
+            "commands": [
+                {
+                    "command": "delete",
+                    "schemaName": "exp",
+                    "queryName": "materials",
+                    "rows": [{"rowId": 1}],
+                }
+            ],
+            "apiVersion": api_version,
+            "extraContext": extra_context,
+            "transacted": transacted,
+            "validateOnly": True,
+        }
+
+        expected_kwargs = {
+            "expected_args": [self.service.get_server_url()],
+            "data": json.dumps(expected_payload, sort_keys=True),
+            "headers": {"Content-Type": "application/json"},
+            "timeout": timeout,
+            "allow_redirects": False,
+        }
+
+        args = [
+            mock_server_context(self.service),
+            commands,
+            api_version,
+            None,  # container_path
+            extra_context,
+            timeout,
+            transacted,
+            validate_only,
+        ]
+
+        success_test(
+            self, self.service.get_successful_response(), save_rows, True, *args, **expected_kwargs
+        )
+
+
 def suite():
     load_tests = unittest.TestLoader().loadTestsFromTestCase
     return unittest.TestSuite(
@@ -469,6 +661,7 @@ def suite():
             load_tests(TestInsertRows),
             load_tests(TestExecuteSQL),
             load_tests(TestSelectRows),
+            load_tests(TestSaveRows),
         ]
     )
 


### PR DESCRIPTION
#### Rationale
This PR adds `save_rows` to the Query API. Accessible via api wrapper as `api.query.save_rows`. 

Implementation note: This makes use of `TypedDict` to improve static type analysis for this API. `TypedDict` was made available starting in Python 3.8. We currently support Python 3.7+, however 3.7 was EOL back in October of 2024. To this end, I've updated our minimum required version to 3.10 which will EOL in October of 2026. Certainly willing to shift this depending on how disruptive this may or may not be to users. I've also updated the `setup.py` to specify `python_requires=">=3.10"` which will make our required version more clear to users and Python repositories. To make sure this doesn't catch anyone off-guard I've bumped the package version to `4.0.0`.

#### Changes
* Add endpoint wrapper for `query-saveRows.api` named `save_rows()`
* Make endpoint accessible via API wrapper
* Add integration and units tests
* Specify `python_requires` in `setup.py`