### PR TITLE
Add "derivationDataScope" to PropertyDescriptor class

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -5,10 +5,11 @@ LabKey Python Client API News
 What's New in the LabKey 4.0.0 package
 ==============================
 
-*Release date: 07/08/2025*
+*Release date: 09/16/2025*
 - Add save_rows API to query module
     - Accessible via API wrappers e.g. api.query.save_rows
 - Update the minimum required version of Python to 3.10
+- Add "derivationDataScope" to PropertyDescriptor class. Thanks @eso-xyme!
 
 What's New in the LabKey 3.4.0 package
 ==============================

--- a/labkey/domain.py
+++ b/labkey/domain.py
@@ -48,6 +48,9 @@ class PropertyDescriptor:
         self.default_value_type = kwargs.pop(
             "default_value_type", kwargs.pop("defaultValueType", None)
         )
+        self.derivation_data_scope = kwargs.pop(
+            "derivation_data_scope", kwargs.pop("derivationDataScope", None)
+        )
         self.description = kwargs.pop("description", None)
         self.dimension = kwargs.pop("dimension", None)
         self.disable_editing = kwargs.pop("disable_editing", kwargs.pop("disableEditing", None))
@@ -120,6 +123,7 @@ class PropertyDescriptor:
             "defaultScale": self.default_scale,
             "defaultValue": self.default_value,
             "defaultValueType": self.default_value_type,
+            "derivationDataScope": self.derivation_data_scope,
             "description": self.description,
             "dimension": self.dimension,
             "disableEditing": self.disable_editing,


### PR DESCRIPTION
#### Rationale
This PR effectively duplicates #84 so that it can be run in CI. I've also prepared the release of v4.0.0.

#### Related Pull Requests
- #84

#### Changes
- Add `derivationDataScope` to PropertyDescriptor class.
- Prepare release notes. Version was bumped within the package with #83.
