### PR TITLE
Require Python 3.11+

### DIFF
--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -5,7 +5,7 @@ LabKey Python Client API News
 What's New in the LabKey 4.0.1 package
 ==============================
 
-*Release date: 09/19/2025*
+*Release date: 09/22/2025*
 - Update the minimum required version of Python to 3.11. Correction from the 4.0.0 release.
 
 What's New in the LabKey 4.0.0 package

--- a/CHANGE.txt
+++ b/CHANGE.txt
@@ -2,6 +2,12 @@
 LabKey Python Client API News
 +++++++++++
 
+What's New in the LabKey 4.0.1 package
+==============================
+
+*Release date: 09/19/2025*
+- Update the minimum required version of Python to 3.11. Correction from the 4.0.0 release.
+
 What's New in the LabKey 4.0.0 package
 ==============================
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ else:
 ```
 
 ## Supported Versions
-Python 3.10+ is fully supported. <!-- Note: update setup.py python_requires if you change this -->
+Python 3.11+ is fully supported. <!-- Note: update setup.py python_requires if you change this -->
 LabKey Server v15.1 and later.
 
 ## Contributing

--- a/labkey/__init__.py
+++ b/labkey/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 __title__ = "labkey"
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 __author__ = "LabKey"
 __license__ = "Apache License 2.0"

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     url="https://github.com/LabKey/labkey-api-python",
     packages=packages,
     package_data={},
-    python_requires=">=3.10", # Note: update README.md supported versions if you change this
+    python_requires=">=3.11", # Note: update README.md supported versions if you change this
     install_requires=["requests"],
     extras_require={"test": tests_require, "dev": dev_require, "build": build_require},
     keywords="labkey api client",


### PR DESCRIPTION
#### Rationale
With `v4.0.0` the minimum supported version of Python was bumped to 3.10, however, that was not correct as we make use of `typings.NotRequired` which was introduced in 3.11. This adjusts that and prepares a new version for release.

#### Related Pull Requests
- #83

#### Changes
- Update minimum compatible version of Python to 3.11+
- Prepare release `v4.0.1`
