### PR TITLE
Fix get_queries_test

### DIFF
--- a/test/integration/test_query.py
+++ b/test/integration/test_query.py
@@ -446,10 +446,3 @@ def test_get_queries(api: APIWrapper):
     assert resp["schemaName"] == "core"
     # By excluding system queries, and user queries, we should have no queries
     assert len(resp["queries"]) == 0
-
-    resp = api.query.get_queries("core", include_columns=False, include_view_data_url=False)
-
-    assert set(resp["queries"][0].keys()) == expected_fields - {
-        "columns",
-        "viewDataUrl",
-    }


### PR DESCRIPTION
#### Rationale
This PR fixes the test failure for get_queries

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Remove test steps that pass include_columns, include_view_data_url flags
  * These test steps don't really add much to the get_queries test, and they result in behavior that is inconsistent between environments. This test passes 100% of the time for me locally, but fails consistently on TC. We have unit tests that verify we're properly translating the snake_case kwargs to camelCase, so I'm not particularly worried about losing coverage.
